### PR TITLE
[feat-customer] 체험단 - 브랜딩 수정 페이지 API 구현 완료 | 체험단 브랜딩 수정 페이지 - 활동 분야, 태그 수정 뷰 수정

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -263,6 +263,20 @@
       <version>1.3.3</version>
     </dependency>
 
+    <!-- 데이터 암호화 의존성 -->
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>31.1-jre</version>
+    </dependency>
+
+    <!-- https://mvnrepository.com/artifact/javax.mail/mail -->
+    <dependency>
+      <groupId>javax.mail</groupId>
+      <artifactId>mail</artifactId>
+      <version>1.4.7</version>
+    </dependency>
+
     <!-- Validation -->
     <dependency>
       <groupId>jakarta.validation</groupId>

--- a/src/main/java/com/nuguna/freview/common/vo/user/foodType/FoodDish.java
+++ b/src/main/java/com/nuguna/freview/common/vo/user/foodType/FoodDish.java
@@ -9,7 +9,7 @@ import lombok.ToString;
 @RequiredArgsConstructor
 public enum FoodDish {
   GUKBAB("국밥", FoodType.KOREAN),
-  TONKATSU("돈까스", FoodType.WESTERN),
+  TONKATSU("돈까스", FoodType.KOREAN),
   JOKBAL("족발", FoodType.KOREAN),
   MAKCHANG("막창", FoodType.KOREAN),
   PIZZA("피자", FoodType.WESTERN),
@@ -20,17 +20,18 @@ public enum FoodDish {
   JJAJANGMYEON("짜장면", FoodType.CHINESE),
   JJAMPPONG("짬뽕", FoodType.CHINESE),
   TANGSOOYOOK("탕수육", FoodType.CHINESE),
-  TTEOKBOKKI("떡볶이", FoodType.KOREAN),
+  TENDON("텐동", FoodType.JAPANESE),
+  SUSHI("초밥", FoodType.JAPANESE),
   GYUDON("규동", FoodType.JAPANESE),
   RAMEN("라멘", FoodType.JAPANESE),
   BREAD("빵", FoodType.BAKERY),
   CAKE("케이크", FoodType.BAKERY),
   COOKIE("쿠키", FoodType.BAKERY),
-  SANDWICH("샌드위치", FoodType.WESTERN),
-  COFFEE("커피", FoodType.BAKERY),
-  CURRY("커리", FoodType.JAPANESE),
-  RICE_NOODLES("쌀국수", FoodType.WESTERN),
-  OTHER("기타", FoodType.WESTERN);
+  SANDWICH("샌드위치", FoodType.BAKERY),
+  COFFEE("커피", FoodType.OTHER),
+  CURRY("커리", FoodType.OTHER),
+  RICE_NOODLES("쌀국수", FoodType.OTHER),
+  OTHER("기타", FoodType.OTHER);
 
   private final String code;
   private final FoodType foodType;

--- a/src/main/java/com/nuguna/freview/common/vo/user/foodType/FoodType.java
+++ b/src/main/java/com/nuguna/freview/common/vo/user/foodType/FoodType.java
@@ -13,7 +13,8 @@ public enum FoodType {
   CHINESE("중식"),
   WESTERN("양식"),
   JAPANESE("일식"),
-  BAKERY("베이커리");
+  BAKERY("베이커리"),
+  OTHER("기타");
 
   private final String code;
 

--- a/src/main/java/com/nuguna/freview/customer/controller/CustomerMyBrandInfoApiController.java
+++ b/src/main/java/com/nuguna/freview/customer/controller/CustomerMyBrandInfoApiController.java
@@ -68,7 +68,9 @@ public class CustomerMyBrandInfoApiController {
   public ResponseEntity<CustomerIntroduceUpdateResponseDTO> updateCustomerIntroduce(
       @Valid @RequestBody CustomerIntroduceUpdateRequestDTO customerIntroduceUpdateRequestDTO
   ) {
-    return null;
+    CustomerIntroduceUpdateResponseDTO responseDTO = customerBrandService.updateCustomerIntroduce(
+        customerIntroduceUpdateRequestDTO);
+    return new ResponseEntity<>(responseDTO, HttpStatus.OK);
   }
 
   @RequestMapping(value = "/tags", method = RequestMethod.PUT)

--- a/src/main/java/com/nuguna/freview/customer/controller/CustomerMyBrandInfoApiController.java
+++ b/src/main/java/com/nuguna/freview/customer/controller/CustomerMyBrandInfoApiController.java
@@ -86,7 +86,9 @@ public class CustomerMyBrandInfoApiController {
   public ResponseEntity<CustomerTagsUpdateResponseDTO> updateCustomerTags(
       @Valid @RequestBody CustomerTagsUpdateRequestDTO customerTagsUpdateRequestDTO
   ) {
-    return null;
+    CustomerTagsUpdateResponseDTO responseDTO = customerBrandService.updateCustomerTags(
+        customerTagsUpdateRequestDTO);
+    return new ResponseEntity<>(responseDTO, HttpStatus.OK);
   }
 
   @RequestMapping(value = "/review", method = RequestMethod.POST)

--- a/src/main/java/com/nuguna/freview/customer/controller/CustomerMyBrandInfoApiController.java
+++ b/src/main/java/com/nuguna/freview/customer/controller/CustomerMyBrandInfoApiController.java
@@ -1,12 +1,88 @@
 package com.nuguna.freview.customer.controller;
 
+import com.nuguna.freview.customer.dto.request.CustomerAgeGroupUpdateRequestDTO;
+import com.nuguna.freview.customer.dto.request.CustomerFoodTypesUpdateRequestDTO;
+import com.nuguna.freview.customer.dto.request.CustomerIntroduceUpdateRequestDTO;
+import com.nuguna.freview.customer.dto.request.CustomerNicknameUpdateRequestDTO;
+import com.nuguna.freview.customer.dto.request.CustomerProfilePhotoUpdateRequestDTO;
+import com.nuguna.freview.customer.dto.request.CustomerReviewRegisterRequestDTO;
+import com.nuguna.freview.customer.dto.request.CustomerTagsUpdateRequestDTO;
+import com.nuguna.freview.customer.dto.response.CustomerAgeGroupUpdateResponseDTO;
+import com.nuguna.freview.customer.dto.response.CustomerFoodTypesUpdateResponseDTO;
+import com.nuguna.freview.customer.dto.response.CustomerIntroduceUpdateResponseDTO;
+import com.nuguna.freview.customer.dto.response.CustomerNicknameUpdateResponseDTO;
+import com.nuguna.freview.customer.dto.response.CustomerProfilePhotoUpdateResponseDTO;
+import com.nuguna.freview.customer.dto.response.CustomerReviewRegisterResponseDTO;
+import com.nuguna.freview.customer.dto.response.CustomerTagsUpdateResponseDTO;
+import com.nuguna.freview.customer.service.CustomerBrandService;
+import javax.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RestController
 @RequestMapping("/api/customer/my/brand-info")
 public class CustomerMyBrandInfoApiController {
-  
+
+  private final CustomerBrandService customerBrandService;
+
+  @Autowired
+  public CustomerMyBrandInfoApiController(CustomerBrandService customerBrandService) {
+    this.customerBrandService = customerBrandService;
+  }
+
+  @RequestMapping(value = "/nickname", method = RequestMethod.PUT)
+  public ResponseEntity<CustomerNicknameUpdateResponseDTO> updateCustomerNickname(
+      @Valid @RequestBody CustomerNicknameUpdateRequestDTO customerNicknameUpdateRequestDTO
+  ) {
+    return null;
+  }
+
+  @RequestMapping(value = "/age-group", method = RequestMethod.PUT)
+  public ResponseEntity<CustomerAgeGroupUpdateResponseDTO> updateCustomerAgeGroup(
+      @Valid @RequestBody CustomerAgeGroupUpdateRequestDTO customerAgeGroupUpdateRequestDTO
+  ) {
+    return null;
+  }
+
+  @RequestMapping(value = "/profile-photo-url", method = RequestMethod.PUT)
+  public ResponseEntity<CustomerProfilePhotoUpdateResponseDTO> updateCustomerProfilePhoto(
+      @Valid @RequestBody CustomerProfilePhotoUpdateRequestDTO customerProfilePhotoUpdateRequestDTO
+  ) {
+    return null;
+  }
+
+  @RequestMapping(value = "/introduce", method = RequestMethod.PUT)
+  public ResponseEntity<CustomerIntroduceUpdateResponseDTO> updateCustomerIntroduce(
+      @Valid @RequestBody CustomerIntroduceUpdateRequestDTO customerIntroduceUpdateRequestDTO
+  ) {
+    return null;
+  }
+
+  @RequestMapping(value = "/tags", method = RequestMethod.PUT)
+  public ResponseEntity<CustomerTagsUpdateResponseDTO> updateCustomerTags(
+      @Valid @RequestBody CustomerTagsUpdateRequestDTO customerTagsUpdateRequestDTO
+  ) {
+    return null;
+  }
+
+  @RequestMapping(value = "/food-types", method = RequestMethod.PUT)
+  public ResponseEntity<CustomerFoodTypesUpdateResponseDTO> updateCustomerFoodTypes(
+      @Valid @RequestBody CustomerFoodTypesUpdateRequestDTO customerFoodTypesUpdateRequestDTO
+  ) {
+    return null;
+  }
+
+  @RequestMapping(value = "/review", method = RequestMethod.POST)
+  public ResponseEntity<CustomerReviewRegisterResponseDTO> registerCustomerReviews(
+      @Valid @RequestBody CustomerReviewRegisterRequestDTO customerReviewRegisterRequestDTO
+  ) {
+    return null;
+  }
+
 }

--- a/src/main/java/com/nuguna/freview/customer/controller/CustomerMyBrandInfoApiController.java
+++ b/src/main/java/com/nuguna/freview/customer/controller/CustomerMyBrandInfoApiController.java
@@ -95,7 +95,9 @@ public class CustomerMyBrandInfoApiController {
   public ResponseEntity<CustomerReviewRegisterResponseDTO> registerCustomerReviews(
       @Valid @RequestBody CustomerReviewRegisterRequestDTO customerReviewRegisterRequestDTO
   ) {
-    return null;
+    CustomerReviewRegisterResponseDTO responseDTO = customerBrandService.registerCustomerReview(
+        customerReviewRegisterRequestDTO);
+    return new ResponseEntity<>(responseDTO, HttpStatus.CREATED);
   }
 
 }

--- a/src/main/java/com/nuguna/freview/customer/controller/CustomerMyBrandInfoApiController.java
+++ b/src/main/java/com/nuguna/freview/customer/controller/CustomerMyBrandInfoApiController.java
@@ -73,16 +73,18 @@ public class CustomerMyBrandInfoApiController {
     return new ResponseEntity<>(responseDTO, HttpStatus.OK);
   }
 
-  @RequestMapping(value = "/tags", method = RequestMethod.PUT)
-  public ResponseEntity<CustomerTagsUpdateResponseDTO> updateCustomerTags(
-      @Valid @RequestBody CustomerTagsUpdateRequestDTO customerTagsUpdateRequestDTO
-  ) {
-    return null;
-  }
-
   @RequestMapping(value = "/food-types", method = RequestMethod.PUT)
   public ResponseEntity<CustomerFoodTypesUpdateResponseDTO> updateCustomerFoodTypes(
       @Valid @RequestBody CustomerFoodTypesUpdateRequestDTO customerFoodTypesUpdateRequestDTO
+  ) {
+    CustomerFoodTypesUpdateResponseDTO responseDTO = customerBrandService.updateCustomerFoodTypes(
+        customerFoodTypesUpdateRequestDTO);
+    return new ResponseEntity<>(responseDTO, HttpStatus.OK);
+  }
+
+  @RequestMapping(value = "/tags", method = RequestMethod.PUT)
+  public ResponseEntity<CustomerTagsUpdateResponseDTO> updateCustomerTags(
+      @Valid @RequestBody CustomerTagsUpdateRequestDTO customerTagsUpdateRequestDTO
   ) {
     return null;
   }

--- a/src/main/java/com/nuguna/freview/customer/controller/CustomerMyBrandInfoApiController.java
+++ b/src/main/java/com/nuguna/freview/customer/controller/CustomerMyBrandInfoApiController.java
@@ -18,6 +18,7 @@ import com.nuguna.freview.customer.service.CustomerBrandService;
 import javax.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -40,7 +41,9 @@ public class CustomerMyBrandInfoApiController {
   public ResponseEntity<CustomerNicknameUpdateResponseDTO> updateCustomerNickname(
       @Valid @RequestBody CustomerNicknameUpdateRequestDTO customerNicknameUpdateRequestDTO
   ) {
-    return null;
+    CustomerNicknameUpdateResponseDTO responseDTO = customerBrandService.updateCustomerNickname(
+        customerNicknameUpdateRequestDTO);
+    return new ResponseEntity<>(responseDTO, HttpStatus.OK);
   }
 
   @RequestMapping(value = "/age-group", method = RequestMethod.PUT)

--- a/src/main/java/com/nuguna/freview/customer/controller/CustomerMyBrandInfoApiController.java
+++ b/src/main/java/com/nuguna/freview/customer/controller/CustomerMyBrandInfoApiController.java
@@ -37,6 +37,15 @@ public class CustomerMyBrandInfoApiController {
     this.customerBrandService = customerBrandService;
   }
 
+  @RequestMapping(value = "/profile-photo-url", method = RequestMethod.PUT)
+  public ResponseEntity<CustomerProfilePhotoUpdateResponseDTO> updateCustomerProfilePhoto(
+      @Valid @RequestBody CustomerProfilePhotoUpdateRequestDTO customerProfilePhotoUpdateRequestDTO
+  ) {
+    CustomerProfilePhotoUpdateResponseDTO responseDTO = customerBrandService.updateCustomerPhotoUrl(
+        customerProfilePhotoUpdateRequestDTO);
+    return new ResponseEntity<>(responseDTO, HttpStatus.OK);
+  }
+
   @RequestMapping(value = "/nickname", method = RequestMethod.PUT)
   public ResponseEntity<CustomerNicknameUpdateResponseDTO> updateCustomerNickname(
       @Valid @RequestBody CustomerNicknameUpdateRequestDTO customerNicknameUpdateRequestDTO
@@ -53,13 +62,6 @@ public class CustomerMyBrandInfoApiController {
     CustomerAgeGroupUpdateResponseDTO responseDTO = customerBrandService.updateCustomerAgeGroup(
         customerAgeGroupUpdateRequestDTO);
     return new ResponseEntity<>(responseDTO, HttpStatus.OK);
-  }
-
-  @RequestMapping(value = "/profile-photo-url", method = RequestMethod.PUT)
-  public ResponseEntity<CustomerProfilePhotoUpdateResponseDTO> updateCustomerProfilePhoto(
-      @Valid @RequestBody CustomerProfilePhotoUpdateRequestDTO customerProfilePhotoUpdateRequestDTO
-  ) {
-    return null;
   }
 
   @RequestMapping(value = "/introduce", method = RequestMethod.PUT)

--- a/src/main/java/com/nuguna/freview/customer/controller/CustomerMyBrandInfoApiController.java
+++ b/src/main/java/com/nuguna/freview/customer/controller/CustomerMyBrandInfoApiController.java
@@ -50,7 +50,9 @@ public class CustomerMyBrandInfoApiController {
   public ResponseEntity<CustomerAgeGroupUpdateResponseDTO> updateCustomerAgeGroup(
       @Valid @RequestBody CustomerAgeGroupUpdateRequestDTO customerAgeGroupUpdateRequestDTO
   ) {
-    return null;
+    CustomerAgeGroupUpdateResponseDTO responseDTO = customerBrandService.updateCustomerAgeGroup(
+        customerAgeGroupUpdateRequestDTO);
+    return new ResponseEntity<>(responseDTO, HttpStatus.OK);
   }
 
   @RequestMapping(value = "/profile-photo-url", method = RequestMethod.PUT)

--- a/src/main/java/com/nuguna/freview/customer/controller/page/CustomerPageController.java
+++ b/src/main/java/com/nuguna/freview/customer/controller/page/CustomerPageController.java
@@ -1,6 +1,5 @@
 package com.nuguna.freview.customer.controller.page;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.nuguna.freview.customer.dto.response.page.CustomerMyBrandPageInfoResponseDTO;
 import com.nuguna.freview.customer.service.CustomerPageService;
 import lombok.extern.slf4j.Slf4j;
@@ -22,8 +21,7 @@ public class CustomerPageController {
   }
 
   @RequestMapping("/my/brand-info")
-  public String customerMyBrandPage(@RequestParam Long userSeq, Model model)
-      throws JsonProcessingException {
+  public String customerMyBrandPage(@RequestParam Long userSeq, Model model) {
     CustomerMyBrandPageInfoResponseDTO brandPageInfo = customerPageService.getBrandPageInfo(
         userSeq);
     model.addAttribute("brandInfo", brandPageInfo);

--- a/src/main/java/com/nuguna/freview/customer/dto/request/CustomerAgeGroupUpdateRequestDTO.java
+++ b/src/main/java/com/nuguna/freview/customer/dto/request/CustomerAgeGroupUpdateRequestDTO.java
@@ -1,0 +1,18 @@
+package com.nuguna.freview.customer.dto.request;
+
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CustomerAgeGroupUpdateRequestDTO {
+
+  @Min(1)
+  private Long userSeq;
+  @NotBlank
+  private String toAgeGroup;
+}

--- a/src/main/java/com/nuguna/freview/customer/dto/request/CustomerAgeGroupUpdateRequestDTO.java
+++ b/src/main/java/com/nuguna/freview/customer/dto/request/CustomerAgeGroupUpdateRequestDTO.java
@@ -1,5 +1,6 @@
 package com.nuguna.freview.customer.dto.request;
 
+import com.nuguna.freview.customer.validation.annotation.ValidAgeGroup;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
@@ -13,6 +14,8 @@ public class CustomerAgeGroupUpdateRequestDTO {
 
   @Min(1)
   private Long userSeq;
+
   @NotBlank
+  @ValidAgeGroup
   private String toAgeGroup;
 }

--- a/src/main/java/com/nuguna/freview/customer/dto/request/CustomerAgeGroupUpdateRequestDTO.java
+++ b/src/main/java/com/nuguna/freview/customer/dto/request/CustomerAgeGroupUpdateRequestDTO.java
@@ -8,8 +8,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@AllArgsConstructor
 @NoArgsConstructor
+@AllArgsConstructor
 public class CustomerAgeGroupUpdateRequestDTO {
 
   @Min(1)
@@ -19,3 +19,4 @@ public class CustomerAgeGroupUpdateRequestDTO {
   @ValidAgeGroup
   private String toAgeGroup;
 }
+

--- a/src/main/java/com/nuguna/freview/customer/dto/request/CustomerFoodTypesUpdateRequestDTO.java
+++ b/src/main/java/com/nuguna/freview/customer/dto/request/CustomerFoodTypesUpdateRequestDTO.java
@@ -1,17 +1,22 @@
 package com.nuguna.freview.customer.dto.request;
 
+import com.nuguna.freview.customer.validation.annotation.ValidFoodTypes;
 import java.util.List;
 import javax.validation.constraints.Min;
+import javax.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@AllArgsConstructor
 @NoArgsConstructor
+@AllArgsConstructor
 public class CustomerFoodTypesUpdateRequestDTO {
 
   @Min(1)
   private Long userSeq;
+
+  @ValidFoodTypes
+  @Size(max = 5, message = "활동 분야는 최대 5개까지 선택할 수 있습니다.")
   private List<String> toFoodTypes;
 }

--- a/src/main/java/com/nuguna/freview/customer/dto/request/CustomerFoodTypesUpdateRequestDTO.java
+++ b/src/main/java/com/nuguna/freview/customer/dto/request/CustomerFoodTypesUpdateRequestDTO.java
@@ -1,0 +1,17 @@
+package com.nuguna.freview.customer.dto.request;
+
+import java.util.List;
+import javax.validation.constraints.Min;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CustomerFoodTypesUpdateRequestDTO {
+
+  @Min(1)
+  private Long userSeq;
+  private List<String> toFoodTypes;
+}

--- a/src/main/java/com/nuguna/freview/customer/dto/request/CustomerFoodTypesUpdateRequestDTO.java
+++ b/src/main/java/com/nuguna/freview/customer/dto/request/CustomerFoodTypesUpdateRequestDTO.java
@@ -3,6 +3,7 @@ package com.nuguna.freview.customer.dto.request;
 import com.nuguna.freview.customer.validation.annotation.ValidFoodTypes;
 import java.util.List;
 import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -17,6 +18,7 @@ public class CustomerFoodTypesUpdateRequestDTO {
   private Long userSeq;
 
   @ValidFoodTypes
+  @NotNull(message = "활동 분야 관련 입력은 필수 값입니다.")
   @Size(max = 5, message = "활동 분야는 최대 5개까지 선택할 수 있습니다.")
   private List<String> toFoodTypes;
 }

--- a/src/main/java/com/nuguna/freview/customer/dto/request/CustomerIntroduceUpdateRequestDTO.java
+++ b/src/main/java/com/nuguna/freview/customer/dto/request/CustomerIntroduceUpdateRequestDTO.java
@@ -1,6 +1,7 @@
 package com.nuguna.freview.customer.dto.request;
 
 import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,6 +14,8 @@ public class CustomerIntroduceUpdateRequestDTO {
 
   @Min(1)
   private Long userSeq;
+  
+  @NotNull(message = "소개글 관련 입력은 필수 값입니다.")
   @Length(max = 100, message = "소개글은 100글자까지 작성 가능합니다.")
   private String toIntroduce;
 }

--- a/src/main/java/com/nuguna/freview/customer/dto/request/CustomerIntroduceUpdateRequestDTO.java
+++ b/src/main/java/com/nuguna/freview/customer/dto/request/CustomerIntroduceUpdateRequestDTO.java
@@ -1,6 +1,7 @@
 package com.nuguna.freview.customer.dto.request;
 
 import javax.validation.constraints.Min;
+import javax.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,5 +13,6 @@ public class CustomerIntroduceUpdateRequestDTO {
 
   @Min(1)
   private Long userSeq;
+  @Size(max = 100, message = "소개글은 100글자까지 작성 가능합니다.")
   private String toIntroduce;
 }

--- a/src/main/java/com/nuguna/freview/customer/dto/request/CustomerIntroduceUpdateRequestDTO.java
+++ b/src/main/java/com/nuguna/freview/customer/dto/request/CustomerIntroduceUpdateRequestDTO.java
@@ -1,18 +1,18 @@
 package com.nuguna.freview.customer.dto.request;
 
 import javax.validation.constraints.Min;
-import javax.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
 
 @Getter
-@AllArgsConstructor
 @NoArgsConstructor
+@AllArgsConstructor
 public class CustomerIntroduceUpdateRequestDTO {
 
   @Min(1)
   private Long userSeq;
-  @Size(max = 100, message = "소개글은 100글자까지 작성 가능합니다.")
+  @Length(max = 100, message = "소개글은 100글자까지 작성 가능합니다.")
   private String toIntroduce;
 }

--- a/src/main/java/com/nuguna/freview/customer/dto/request/CustomerIntroduceUpdateRequestDTO.java
+++ b/src/main/java/com/nuguna/freview/customer/dto/request/CustomerIntroduceUpdateRequestDTO.java
@@ -1,0 +1,16 @@
+package com.nuguna.freview.customer.dto.request;
+
+import javax.validation.constraints.Min;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CustomerIntroduceUpdateRequestDTO {
+
+  @Min(1)
+  private Long userSeq;
+  private String toIntroduce;
+}

--- a/src/main/java/com/nuguna/freview/customer/dto/request/CustomerNicknameUpdateRequestDTO.java
+++ b/src/main/java/com/nuguna/freview/customer/dto/request/CustomerNicknameUpdateRequestDTO.java
@@ -2,10 +2,10 @@ package com.nuguna.freview.customer.dto.request;
 
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
 
 @Getter
 @NoArgsConstructor
@@ -16,6 +16,6 @@ public class CustomerNicknameUpdateRequestDTO {
   private Long userSeq;
 
   @NotBlank(message = "닉네임은 비어둘 수 없습니다.")
-  @Size(min = 1, max = 50, message = "닉네임은 1글자 ~ 50글자 이하여야 합니다.")
+  @Length(min = 1, max = 50, message = "닉네임은 1글자 ~ 50글자 이하여야 합니다.")
   private String toNickname;
 }

--- a/src/main/java/com/nuguna/freview/customer/dto/request/CustomerNicknameUpdateRequestDTO.java
+++ b/src/main/java/com/nuguna/freview/customer/dto/request/CustomerNicknameUpdateRequestDTO.java
@@ -1,0 +1,18 @@
+package com.nuguna.freview.customer.dto.request;
+
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CustomerNicknameUpdateRequestDTO {
+
+  @Min(1)
+  private Long userSeq;
+  @NotBlank
+  private String toNickname;
+}

--- a/src/main/java/com/nuguna/freview/customer/dto/request/CustomerNicknameUpdateRequestDTO.java
+++ b/src/main/java/com/nuguna/freview/customer/dto/request/CustomerNicknameUpdateRequestDTO.java
@@ -2,17 +2,20 @@ package com.nuguna.freview.customer.dto.request;
 
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@AllArgsConstructor
 @NoArgsConstructor
+@AllArgsConstructor
 public class CustomerNicknameUpdateRequestDTO {
 
-  @Min(1)
+  @Min(value = 1, message = "유저 번호는 1번 이상이어야 합니다.")
   private Long userSeq;
-  @NotBlank
+
+  @NotBlank(message = "닉네임은 비어둘 수 없습니다.")
+  @Size(min = 1, max = 50, message = "닉네임은 1글자 ~ 50글자 이하여야 합니다.")
   private String toNickname;
 }

--- a/src/main/java/com/nuguna/freview/customer/dto/request/CustomerProfilePhotoUpdateRequestDTO.java
+++ b/src/main/java/com/nuguna/freview/customer/dto/request/CustomerProfilePhotoUpdateRequestDTO.java
@@ -6,8 +6,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@AllArgsConstructor
 @NoArgsConstructor
+@AllArgsConstructor
 public class CustomerProfilePhotoUpdateRequestDTO {
 
   @Min(1)

--- a/src/main/java/com/nuguna/freview/customer/dto/request/CustomerProfilePhotoUpdateRequestDTO.java
+++ b/src/main/java/com/nuguna/freview/customer/dto/request/CustomerProfilePhotoUpdateRequestDTO.java
@@ -1,0 +1,16 @@
+package com.nuguna.freview.customer.dto.request;
+
+import javax.validation.constraints.Min;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CustomerProfilePhotoUpdateRequestDTO {
+
+  @Min(1)
+  private Long userSeq;
+  private String toProfilePhotoUrl;
+}

--- a/src/main/java/com/nuguna/freview/customer/dto/request/CustomerProfilePhotoUpdateRequestDTO.java
+++ b/src/main/java/com/nuguna/freview/customer/dto/request/CustomerProfilePhotoUpdateRequestDTO.java
@@ -1,6 +1,7 @@
 package com.nuguna.freview.customer.dto.request;
 
 import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,5 +13,7 @@ public class CustomerProfilePhotoUpdateRequestDTO {
 
   @Min(1)
   private Long userSeq;
+
+  @NotNull(message = "프로필 사진 관련 입력은 필수 값입니다.")
   private String toProfilePhotoUrl;
 }

--- a/src/main/java/com/nuguna/freview/customer/dto/request/CustomerReviewRegisterRequestDTO.java
+++ b/src/main/java/com/nuguna/freview/customer/dto/request/CustomerReviewRegisterRequestDTO.java
@@ -2,6 +2,7 @@ package com.nuguna.freview.customer.dto.request;
 
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,6 +14,11 @@ public class CustomerReviewRegisterRequestDTO {
 
   @Min(1)
   private Long userSeq;
+
+  @Min(1)
+  @NotNull
+  private Long reviewSeq;
+
   @NotBlank(message = "리뷰 URL은 비어있는 값이면 안됩니다.")
   private String reviewUrl;
 }

--- a/src/main/java/com/nuguna/freview/customer/dto/request/CustomerReviewRegisterRequestDTO.java
+++ b/src/main/java/com/nuguna/freview/customer/dto/request/CustomerReviewRegisterRequestDTO.java
@@ -13,6 +13,6 @@ public class CustomerReviewRegisterRequestDTO {
 
   @Min(1)
   private Long userSeq;
-  @NotBlank
+  @NotBlank(message = "리뷰 URL은 비어있는 값이면 안됩니다.")
   private String reviewUrl;
 }

--- a/src/main/java/com/nuguna/freview/customer/dto/request/CustomerReviewRegisterRequestDTO.java
+++ b/src/main/java/com/nuguna/freview/customer/dto/request/CustomerReviewRegisterRequestDTO.java
@@ -7,8 +7,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@AllArgsConstructor
 @NoArgsConstructor
+@AllArgsConstructor
 public class CustomerReviewRegisterRequestDTO {
 
   @Min(1)

--- a/src/main/java/com/nuguna/freview/customer/dto/request/CustomerReviewRegisterRequestDTO.java
+++ b/src/main/java/com/nuguna/freview/customer/dto/request/CustomerReviewRegisterRequestDTO.java
@@ -1,0 +1,18 @@
+package com.nuguna.freview.customer.dto.request;
+
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CustomerReviewRegisterRequestDTO {
+
+  @Min(1)
+  private Long userSeq;
+  @NotBlank
+  private String reviewUrl;
+}

--- a/src/main/java/com/nuguna/freview/customer/dto/request/CustomerTagsUpdateRequestDTO.java
+++ b/src/main/java/com/nuguna/freview/customer/dto/request/CustomerTagsUpdateRequestDTO.java
@@ -1,7 +1,9 @@
 package com.nuguna.freview.customer.dto.request;
 
+import com.nuguna.freview.customer.validation.annotation.ValidCustomerTags;
 import java.util.List;
 import javax.validation.constraints.Min;
+import javax.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,5 +15,8 @@ public class CustomerTagsUpdateRequestDTO {
 
   @Min(1)
   private Long userSeq;
+
+  @ValidCustomerTags
+  @Size(max = 2, message = "태그는 최대 2개까지 선택할 수 있습니다.")
   private List<String> toTags;
 }

--- a/src/main/java/com/nuguna/freview/customer/dto/request/CustomerTagsUpdateRequestDTO.java
+++ b/src/main/java/com/nuguna/freview/customer/dto/request/CustomerTagsUpdateRequestDTO.java
@@ -3,6 +3,7 @@ package com.nuguna.freview.customer.dto.request;
 import com.nuguna.freview.customer.validation.annotation.ValidCustomerTags;
 import java.util.List;
 import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -17,6 +18,7 @@ public class CustomerTagsUpdateRequestDTO {
   private Long userSeq;
 
   @ValidCustomerTags
+  @NotNull(message = "태그 관련 입력은 필수 값입니다.")
   @Size(max = 2, message = "태그는 최대 2개까지 선택할 수 있습니다.")
   private List<String> toTags;
 }

--- a/src/main/java/com/nuguna/freview/customer/dto/request/CustomerTagsUpdateRequestDTO.java
+++ b/src/main/java/com/nuguna/freview/customer/dto/request/CustomerTagsUpdateRequestDTO.java
@@ -1,0 +1,17 @@
+package com.nuguna.freview.customer.dto.request;
+
+import java.util.List;
+import javax.validation.constraints.Min;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CustomerTagsUpdateRequestDTO {
+
+  @Min(1)
+  private Long userSeq;
+  private List<String> toTags;
+}

--- a/src/main/java/com/nuguna/freview/customer/dto/request/CustomerTagsUpdateRequestDTO.java
+++ b/src/main/java/com/nuguna/freview/customer/dto/request/CustomerTagsUpdateRequestDTO.java
@@ -7,8 +7,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@AllArgsConstructor
 @NoArgsConstructor
+@AllArgsConstructor
 public class CustomerTagsUpdateRequestDTO {
 
   @Min(1)

--- a/src/main/java/com/nuguna/freview/customer/dto/request/TestRequestDTO.java
+++ b/src/main/java/com/nuguna/freview/customer/dto/request/TestRequestDTO.java
@@ -1,5 +1,0 @@
-package com.nuguna.freview.customer.dto.request;
-
-public class TestRequestDTO {
-
-}

--- a/src/main/java/com/nuguna/freview/customer/dto/response/CustomerAgeGroupUpdateResponseDTO.java
+++ b/src/main/java/com/nuguna/freview/customer/dto/response/CustomerAgeGroupUpdateResponseDTO.java
@@ -5,8 +5,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@AllArgsConstructor
 @NoArgsConstructor
+@AllArgsConstructor
 public class CustomerAgeGroupUpdateResponseDTO {
 
   private String ageGroup;

--- a/src/main/java/com/nuguna/freview/customer/dto/response/CustomerAgeGroupUpdateResponseDTO.java
+++ b/src/main/java/com/nuguna/freview/customer/dto/response/CustomerAgeGroupUpdateResponseDTO.java
@@ -1,0 +1,13 @@
+package com.nuguna.freview.customer.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CustomerAgeGroupUpdateResponseDTO {
+
+  private String ageGroup;
+}

--- a/src/main/java/com/nuguna/freview/customer/dto/response/CustomerFoodTypesUpdateResponseDTO.java
+++ b/src/main/java/com/nuguna/freview/customer/dto/response/CustomerFoodTypesUpdateResponseDTO.java
@@ -6,8 +6,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@AllArgsConstructor
 @NoArgsConstructor
+@AllArgsConstructor
 public class CustomerFoodTypesUpdateResponseDTO {
 
   private List<String> foodTypes;

--- a/src/main/java/com/nuguna/freview/customer/dto/response/CustomerFoodTypesUpdateResponseDTO.java
+++ b/src/main/java/com/nuguna/freview/customer/dto/response/CustomerFoodTypesUpdateResponseDTO.java
@@ -1,0 +1,14 @@
+package com.nuguna.freview.customer.dto.response;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CustomerFoodTypesUpdateResponseDTO {
+
+  private List<String> foodTypes;
+}

--- a/src/main/java/com/nuguna/freview/customer/dto/response/CustomerIntroduceUpdateResponseDTO.java
+++ b/src/main/java/com/nuguna/freview/customer/dto/response/CustomerIntroduceUpdateResponseDTO.java
@@ -5,8 +5,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@AllArgsConstructor
 @NoArgsConstructor
+@AllArgsConstructor
 public class CustomerIntroduceUpdateResponseDTO {
 
   private String introduce;

--- a/src/main/java/com/nuguna/freview/customer/dto/response/CustomerIntroduceUpdateResponseDTO.java
+++ b/src/main/java/com/nuguna/freview/customer/dto/response/CustomerIntroduceUpdateResponseDTO.java
@@ -1,0 +1,13 @@
+package com.nuguna.freview.customer.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CustomerIntroduceUpdateResponseDTO {
+
+  private String introduce;
+}

--- a/src/main/java/com/nuguna/freview/customer/dto/response/CustomerNicknameUpdateResponseDTO.java
+++ b/src/main/java/com/nuguna/freview/customer/dto/response/CustomerNicknameUpdateResponseDTO.java
@@ -1,0 +1,14 @@
+package com.nuguna.freview.customer.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CustomerNicknameUpdateResponseDTO {
+
+  private String nickname;
+
+}

--- a/src/main/java/com/nuguna/freview/customer/dto/response/CustomerNicknameUpdateResponseDTO.java
+++ b/src/main/java/com/nuguna/freview/customer/dto/response/CustomerNicknameUpdateResponseDTO.java
@@ -10,5 +10,4 @@ import lombok.NoArgsConstructor;
 public class CustomerNicknameUpdateResponseDTO {
 
   private String nickname;
-
 }

--- a/src/main/java/com/nuguna/freview/customer/dto/response/CustomerNicknameUpdateResponseDTO.java
+++ b/src/main/java/com/nuguna/freview/customer/dto/response/CustomerNicknameUpdateResponseDTO.java
@@ -5,8 +5,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@AllArgsConstructor
 @NoArgsConstructor
+@AllArgsConstructor
 public class CustomerNicknameUpdateResponseDTO {
 
   private String nickname;

--- a/src/main/java/com/nuguna/freview/customer/dto/response/CustomerProfilePhotoUpdateResponseDTO.java
+++ b/src/main/java/com/nuguna/freview/customer/dto/response/CustomerProfilePhotoUpdateResponseDTO.java
@@ -1,0 +1,14 @@
+package com.nuguna.freview.customer.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CustomerProfilePhotoUpdateResponseDTO {
+
+  private String profilePhotoUrl;
+
+}

--- a/src/main/java/com/nuguna/freview/customer/dto/response/CustomerProfilePhotoUpdateResponseDTO.java
+++ b/src/main/java/com/nuguna/freview/customer/dto/response/CustomerProfilePhotoUpdateResponseDTO.java
@@ -10,5 +10,4 @@ import lombok.NoArgsConstructor;
 public class CustomerProfilePhotoUpdateResponseDTO {
 
   private String profilePhotoUrl;
-
 }

--- a/src/main/java/com/nuguna/freview/customer/dto/response/CustomerProfilePhotoUpdateResponseDTO.java
+++ b/src/main/java/com/nuguna/freview/customer/dto/response/CustomerProfilePhotoUpdateResponseDTO.java
@@ -5,8 +5,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@AllArgsConstructor
 @NoArgsConstructor
+@AllArgsConstructor
 public class CustomerProfilePhotoUpdateResponseDTO {
 
   private String profilePhotoUrl;

--- a/src/main/java/com/nuguna/freview/customer/dto/response/CustomerReviewRegisterResponseDTO.java
+++ b/src/main/java/com/nuguna/freview/customer/dto/response/CustomerReviewRegisterResponseDTO.java
@@ -5,8 +5,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@AllArgsConstructor
 @NoArgsConstructor
+@AllArgsConstructor
 public class CustomerReviewRegisterResponseDTO {
 
   private String profilePhotoUrl;

--- a/src/main/java/com/nuguna/freview/customer/dto/response/CustomerReviewRegisterResponseDTO.java
+++ b/src/main/java/com/nuguna/freview/customer/dto/response/CustomerReviewRegisterResponseDTO.java
@@ -1,0 +1,13 @@
+package com.nuguna.freview.customer.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CustomerReviewRegisterResponseDTO {
+
+  private String profilePhotoUrl;
+}

--- a/src/main/java/com/nuguna/freview/customer/dto/response/CustomerReviewRegisterResponseDTO.java
+++ b/src/main/java/com/nuguna/freview/customer/dto/response/CustomerReviewRegisterResponseDTO.java
@@ -9,5 +9,5 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class CustomerReviewRegisterResponseDTO {
 
-  private String profilePhotoUrl;
+  private String reviewUrl;
 }

--- a/src/main/java/com/nuguna/freview/customer/dto/response/CustomerTagsUpdateResponseDTO.java
+++ b/src/main/java/com/nuguna/freview/customer/dto/response/CustomerTagsUpdateResponseDTO.java
@@ -1,0 +1,14 @@
+package com.nuguna.freview.customer.dto.response;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CustomerTagsUpdateResponseDTO {
+
+  private List<String> foodTypes;
+}

--- a/src/main/java/com/nuguna/freview/customer/dto/response/CustomerTagsUpdateResponseDTO.java
+++ b/src/main/java/com/nuguna/freview/customer/dto/response/CustomerTagsUpdateResponseDTO.java
@@ -6,8 +6,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@AllArgsConstructor
 @NoArgsConstructor
+@AllArgsConstructor
 public class CustomerTagsUpdateResponseDTO {
 
   private List<String> foodTypes;

--- a/src/main/java/com/nuguna/freview/customer/dto/response/CustomerTagsUpdateResponseDTO.java
+++ b/src/main/java/com/nuguna/freview/customer/dto/response/CustomerTagsUpdateResponseDTO.java
@@ -10,5 +10,5 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class CustomerTagsUpdateResponseDTO {
 
-  private List<String> foodTypes;
+  private List<String> tags;
 }

--- a/src/main/java/com/nuguna/freview/customer/dto/response/TestResponseDTO.java
+++ b/src/main/java/com/nuguna/freview/customer/dto/response/TestResponseDTO.java
@@ -1,5 +1,0 @@
-package com.nuguna.freview.customer.dto.response;
-
-public class TestResponseDTO {
-
-}

--- a/src/main/java/com/nuguna/freview/customer/exception/AlreadyExistNicknameException.java
+++ b/src/main/java/com/nuguna/freview/customer/exception/AlreadyExistNicknameException.java
@@ -1,0 +1,12 @@
+package com.nuguna.freview.customer.exception;
+
+public class AlreadyExistNicknameException extends RuntimeException {
+
+  public AlreadyExistNicknameException() {
+    super();
+  }
+
+  public AlreadyExistNicknameException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/com/nuguna/freview/customer/exception/IllegalReviewException.java
+++ b/src/main/java/com/nuguna/freview/customer/exception/IllegalReviewException.java
@@ -1,0 +1,12 @@
+package com.nuguna.freview.customer.exception;
+
+public class IllegalReviewException extends RuntimeException {
+
+  public IllegalReviewException() {
+    super();
+  }
+
+  public IllegalReviewException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/com/nuguna/freview/customer/exception/TestUserDefinedException.java
+++ b/src/main/java/com/nuguna/freview/customer/exception/TestUserDefinedException.java
@@ -1,5 +1,0 @@
-package com.nuguna.freview.customer.exception;
-
-public class TestUserDefinedException {
-
-}

--- a/src/main/java/com/nuguna/freview/customer/exception/handler/CustomerApiExceptionHandler.java
+++ b/src/main/java/com/nuguna/freview/customer/exception/handler/CustomerApiExceptionHandler.java
@@ -1,0 +1,19 @@
+package com.nuguna.freview.customer.exception.handler;
+
+import com.nuguna.freview.customer.exception.AlreadyExistNicknameException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@ResponseBody
+@ControllerAdvice
+public class CustomerApiExceptionHandler {
+
+  @ExceptionHandler(AlreadyExistNicknameException.class)
+  public ResponseEntity<String> handleNicknameException(AlreadyExistNicknameException ex) {
+    return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
+  }
+
+}

--- a/src/main/java/com/nuguna/freview/customer/exception/handler/CustomerApiExceptionHandler.java
+++ b/src/main/java/com/nuguna/freview/customer/exception/handler/CustomerApiExceptionHandler.java
@@ -1,6 +1,8 @@
 package com.nuguna.freview.customer.exception.handler;
 
 import com.nuguna.freview.customer.exception.AlreadyExistNicknameException;
+import com.nuguna.freview.customer.exception.IllegalReviewException;
+import com.nuguna.freview.global.exception.ErrorResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -12,8 +14,13 @@ import org.springframework.web.bind.annotation.ResponseBody;
 public class CustomerApiExceptionHandler {
 
   @ExceptionHandler(AlreadyExistNicknameException.class)
-  public ResponseEntity<String> handleNicknameException(AlreadyExistNicknameException ex) {
-    return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
+  public ResponseEntity<ErrorResponse> handleNicknameException(AlreadyExistNicknameException ex) {
+    return new ResponseEntity<>(new ErrorResponse(ex.getMessage(), null), HttpStatus.BAD_REQUEST);
+  }
+
+  @ExceptionHandler(IllegalReviewException.class)
+  public ResponseEntity<ErrorResponse> handleReviewException(IllegalReviewException ex) {
+    return new ResponseEntity<>(new ErrorResponse(ex.getMessage(), null), HttpStatus.NOT_FOUND);
   }
 
 }

--- a/src/main/java/com/nuguna/freview/customer/exception/handler/TestExceptionHandler.java
+++ b/src/main/java/com/nuguna/freview/customer/exception/handler/TestExceptionHandler.java
@@ -1,5 +1,0 @@
-package com.nuguna.freview.customer.exception.handler;
-
-public class TestExceptionHandler {
-
-}

--- a/src/main/java/com/nuguna/freview/customer/mapper/CustomerBrandMapper.java
+++ b/src/main/java/com/nuguna/freview/customer/mapper/CustomerBrandMapper.java
@@ -29,4 +29,7 @@ public interface CustomerBrandMapper {
 
   void insertTags(@Param("userSeq") Long userSeq, @Param("toTags") List<String> toTags);
 
+  Boolean checkIsValidReview(@Param("userSeq") Long userSeq, @Param("reviewSeq") Long reviewSeq);
+
+  void registerReview(@Param("reviewSeq") Long reviewSeq, @Param("reviewUrl") String reviewUrl);
 }

--- a/src/main/java/com/nuguna/freview/customer/mapper/CustomerBrandMapper.java
+++ b/src/main/java/com/nuguna/freview/customer/mapper/CustomerBrandMapper.java
@@ -25,4 +25,8 @@ public interface CustomerBrandMapper {
   void insertFoodTypes(@Param("userSeq") Long userSeq,
       @Param("toFoodTypes") List<String> toFoodTypes);
 
+  void deleteTagsByUserSeq(Long userSeq);
+
+  void insertTags(@Param("userSeq") Long userSeq, @Param("toTags") List<String> toTags);
+
 }

--- a/src/main/java/com/nuguna/freview/customer/mapper/CustomerBrandMapper.java
+++ b/src/main/java/com/nuguna/freview/customer/mapper/CustomerBrandMapper.java
@@ -1,5 +1,6 @@
 package com.nuguna.freview.customer.mapper;
 
+import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
@@ -18,5 +19,10 @@ public interface CustomerBrandMapper {
 
   void updateIntroduce(@Param("userSeq") Long userSeq,
       @Param("toIntroduce") String toIntroduce);
+
+  void deleteFoodTypesByUserSeq(Long userSeq);
+
+  void insertFoodTypes(@Param("userSeq") Long userSeq,
+      @Param("toFoodTypes") List<String> toFoodTypes);
 
 }

--- a/src/main/java/com/nuguna/freview/customer/mapper/CustomerBrandMapper.java
+++ b/src/main/java/com/nuguna/freview/customer/mapper/CustomerBrandMapper.java
@@ -13,4 +13,8 @@ public interface CustomerBrandMapper {
 
   void updateAgeGroup(@Param("userSeq") Long userSeq, @Param("toAgeGroup") String toAgeGroup);
 
+  void updateProfilePhotoUrl(@Param("userSeq") Long userSeq,
+      @Param("toProfilePhotoUrl") String toProfilePhotoUrl);
+
+
 }

--- a/src/main/java/com/nuguna/freview/customer/mapper/CustomerBrandMapper.java
+++ b/src/main/java/com/nuguna/freview/customer/mapper/CustomerBrandMapper.java
@@ -11,4 +11,6 @@ public interface CustomerBrandMapper {
 
   void updateNickname(@Param("userSeq") Long userSeq, @Param("toNickname") String toNickname);
 
+  void updateAgeGroup(@Param("userSeq") Long userSeq, @Param("toAgeGroup") String toAgeGroup);
+
 }

--- a/src/main/java/com/nuguna/freview/customer/mapper/CustomerBrandMapper.java
+++ b/src/main/java/com/nuguna/freview/customer/mapper/CustomerBrandMapper.java
@@ -1,0 +1,8 @@
+package com.nuguna.freview.customer.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface CustomerBrandMapper {
+
+}

--- a/src/main/java/com/nuguna/freview/customer/mapper/CustomerBrandMapper.java
+++ b/src/main/java/com/nuguna/freview/customer/mapper/CustomerBrandMapper.java
@@ -16,5 +16,7 @@ public interface CustomerBrandMapper {
   void updateProfilePhotoUrl(@Param("userSeq") Long userSeq,
       @Param("toProfilePhotoUrl") String toProfilePhotoUrl);
 
+  void updateIntroduce(@Param("userSeq") Long userSeq,
+      @Param("toIntroduce") String toIntroduce);
 
 }

--- a/src/main/java/com/nuguna/freview/customer/mapper/CustomerBrandMapper.java
+++ b/src/main/java/com/nuguna/freview/customer/mapper/CustomerBrandMapper.java
@@ -1,8 +1,14 @@
 package com.nuguna.freview.customer.mapper;
 
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 @Mapper
 public interface CustomerBrandMapper {
+
+  Boolean checkNicknameExist(@Param("toNickname") String toNickname,
+      @Param("userSeq") Long userSeq);
+
+  void updateNickname(@Param("userSeq") Long userSeq, @Param("toNickname") String toNickname);
 
 }

--- a/src/main/java/com/nuguna/freview/customer/service/CustomerBrandService.java
+++ b/src/main/java/com/nuguna/freview/customer/service/CustomerBrandService.java
@@ -1,0 +1,5 @@
+package com.nuguna.freview.customer.service;
+
+public interface CustomerBrandService {
+
+}

--- a/src/main/java/com/nuguna/freview/customer/service/CustomerBrandService.java
+++ b/src/main/java/com/nuguna/freview/customer/service/CustomerBrandService.java
@@ -23,11 +23,11 @@ public interface CustomerBrandService {
   CustomerAgeGroupUpdateResponseDTO updateCustomerAgeGroup(
       CustomerAgeGroupUpdateRequestDTO customerAgeGroupUpdateRequestDTO);
 
-  CustomerIntroduceUpdateResponseDTO updateCustomerIntroduce(
-      CustomerIntroduceUpdateRequestDTO customerIntroduceUpdateRequestDTO);
-
   CustomerProfilePhotoUpdateResponseDTO updateCustomerPhotoUrl(
       CustomerProfilePhotoUpdateRequestDTO customerProfilePhotoUpdateRequestDTO);
+
+  CustomerIntroduceUpdateResponseDTO updateCustomerIntroduce(
+      CustomerIntroduceUpdateRequestDTO customerIntroduceUpdateRequestDTO);
 
   CustomerFoodTypesUpdateResponseDTO updateCustomerFoodTypes(
       CustomerFoodTypesUpdateRequestDTO customerFoodTypesUpdateRequestDTO);

--- a/src/main/java/com/nuguna/freview/customer/service/CustomerBrandService.java
+++ b/src/main/java/com/nuguna/freview/customer/service/CustomerBrandService.java
@@ -1,5 +1,40 @@
 package com.nuguna.freview.customer.service;
 
+import com.nuguna.freview.customer.dto.request.CustomerAgeGroupUpdateRequestDTO;
+import com.nuguna.freview.customer.dto.request.CustomerFoodTypesUpdateRequestDTO;
+import com.nuguna.freview.customer.dto.request.CustomerIntroduceUpdateRequestDTO;
+import com.nuguna.freview.customer.dto.request.CustomerNicknameUpdateRequestDTO;
+import com.nuguna.freview.customer.dto.request.CustomerProfilePhotoUpdateRequestDTO;
+import com.nuguna.freview.customer.dto.request.CustomerReviewRegisterRequestDTO;
+import com.nuguna.freview.customer.dto.request.CustomerTagsUpdateRequestDTO;
+import com.nuguna.freview.customer.dto.response.CustomerAgeGroupUpdateResponseDTO;
+import com.nuguna.freview.customer.dto.response.CustomerFoodTypesUpdateResponseDTO;
+import com.nuguna.freview.customer.dto.response.CustomerIntroduceUpdateResponseDTO;
+import com.nuguna.freview.customer.dto.response.CustomerNicknameUpdateResponseDTO;
+import com.nuguna.freview.customer.dto.response.CustomerProfilePhotoUpdateResponseDTO;
+import com.nuguna.freview.customer.dto.response.CustomerReviewRegisterResponseDTO;
+import com.nuguna.freview.customer.dto.response.CustomerTagsUpdateResponseDTO;
+
 public interface CustomerBrandService {
 
+  CustomerNicknameUpdateResponseDTO updateCustomerNickname(
+      CustomerNicknameUpdateRequestDTO customerNicknameUpdateRequestDTO);
+
+  CustomerAgeGroupUpdateResponseDTO updateCustomerAgeGroup(
+      CustomerAgeGroupUpdateRequestDTO customerAgeGroupUpdateRequestDTO);
+
+  CustomerIntroduceUpdateResponseDTO updateCustomerIntroduce(
+      CustomerIntroduceUpdateRequestDTO customerIntroduceUpdateRequestDTO);
+
+  CustomerProfilePhotoUpdateResponseDTO updateCustomerPhotoUrl(
+      CustomerProfilePhotoUpdateRequestDTO customerProfilePhotoUpdateRequestDTO);
+
+  CustomerFoodTypesUpdateResponseDTO updateCustomerFoodTypes(
+      CustomerFoodTypesUpdateRequestDTO customerFoodTypesUpdateRequestDTO);
+
+  CustomerTagsUpdateResponseDTO updateCustomerTags(
+      CustomerTagsUpdateRequestDTO customerTagsUpdateRequestDTO);
+
+  CustomerReviewRegisterResponseDTO registerCustomerReview(
+      CustomerReviewRegisterRequestDTO customerReviewRegisterRequestDTO);
 }

--- a/src/main/java/com/nuguna/freview/customer/service/impl/CustomerBrandServiceImpl.java
+++ b/src/main/java/com/nuguna/freview/customer/service/impl/CustomerBrandServiceImpl.java
@@ -17,6 +17,7 @@ import com.nuguna.freview.customer.dto.response.CustomerTagsUpdateResponseDTO;
 import com.nuguna.freview.customer.exception.AlreadyExistNicknameException;
 import com.nuguna.freview.customer.mapper.CustomerBrandMapper;
 import com.nuguna.freview.customer.service.CustomerBrandService;
+import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -75,7 +76,11 @@ public class CustomerBrandServiceImpl implements CustomerBrandService {
   @Override
   public CustomerFoodTypesUpdateResponseDTO updateCustomerFoodTypes(
       CustomerFoodTypesUpdateRequestDTO customerFoodTypesUpdateRequestDTO) {
-    return null;
+    Long userSeq = customerFoodTypesUpdateRequestDTO.getUserSeq();
+    List<String> toFoodTypes = customerFoodTypesUpdateRequestDTO.getToFoodTypes();
+    customerBrandMapper.deleteFoodTypesByUserSeq(userSeq);
+    customerBrandMapper.insertFoodTypes(userSeq, toFoodTypes);
+    return new CustomerFoodTypesUpdateResponseDTO(toFoodTypes);
   }
 
   @Override

--- a/src/main/java/com/nuguna/freview/customer/service/impl/CustomerBrandServiceImpl.java
+++ b/src/main/java/com/nuguna/freview/customer/service/impl/CustomerBrandServiceImpl.java
@@ -48,7 +48,10 @@ public class CustomerBrandServiceImpl implements CustomerBrandService {
   @Override
   public CustomerAgeGroupUpdateResponseDTO updateCustomerAgeGroup(
       CustomerAgeGroupUpdateRequestDTO customerAgeGroupUpdateRequestDTO) {
-    return null;
+    Long userSeq = customerAgeGroupUpdateRequestDTO.getUserSeq();
+    String toAgeGroup = customerAgeGroupUpdateRequestDTO.getToAgeGroup();
+    customerBrandMapper.updateAgeGroup(userSeq, toAgeGroup);
+    return new CustomerAgeGroupUpdateResponseDTO(toAgeGroup);
   }
 
   @Override

--- a/src/main/java/com/nuguna/freview/customer/service/impl/CustomerBrandServiceImpl.java
+++ b/src/main/java/com/nuguna/freview/customer/service/impl/CustomerBrandServiceImpl.java
@@ -66,7 +66,10 @@ public class CustomerBrandServiceImpl implements CustomerBrandService {
   @Override
   public CustomerIntroduceUpdateResponseDTO updateCustomerIntroduce(
       CustomerIntroduceUpdateRequestDTO customerIntroduceUpdateRequestDTO) {
-    return null;
+    Long userSeq = customerIntroduceUpdateRequestDTO.getUserSeq();
+    String toIntroduce = customerIntroduceUpdateRequestDTO.getToIntroduce();
+    customerBrandMapper.updateIntroduce(userSeq, toIntroduce);
+    return new CustomerIntroduceUpdateResponseDTO(toIntroduce);
   }
 
   @Override

--- a/src/main/java/com/nuguna/freview/customer/service/impl/CustomerBrandServiceImpl.java
+++ b/src/main/java/com/nuguna/freview/customer/service/impl/CustomerBrandServiceImpl.java
@@ -55,14 +55,17 @@ public class CustomerBrandServiceImpl implements CustomerBrandService {
   }
 
   @Override
-  public CustomerIntroduceUpdateResponseDTO updateCustomerIntroduce(
-      CustomerIntroduceUpdateRequestDTO customerIntroduceUpdateRequestDTO) {
-    return null;
+  public CustomerProfilePhotoUpdateResponseDTO updateCustomerPhotoUrl(
+      CustomerProfilePhotoUpdateRequestDTO customerProfilePhotoUpdateRequestDTO) {
+    Long userSeq = customerProfilePhotoUpdateRequestDTO.getUserSeq();
+    String toProfilePhotoUrl = customerProfilePhotoUpdateRequestDTO.getToProfilePhotoUrl();
+    customerBrandMapper.updateProfilePhotoUrl(userSeq, toProfilePhotoUrl);
+    return new CustomerProfilePhotoUpdateResponseDTO(toProfilePhotoUrl);
   }
 
   @Override
-  public CustomerProfilePhotoUpdateResponseDTO updateCustomerPhotoUrl(
-      CustomerProfilePhotoUpdateRequestDTO customerProfilePhotoUpdateRequestDTO) {
+  public CustomerIntroduceUpdateResponseDTO updateCustomerIntroduce(
+      CustomerIntroduceUpdateRequestDTO customerIntroduceUpdateRequestDTO) {
     return null;
   }
 

--- a/src/main/java/com/nuguna/freview/customer/service/impl/CustomerBrandServiceImpl.java
+++ b/src/main/java/com/nuguna/freview/customer/service/impl/CustomerBrandServiceImpl.java
@@ -15,6 +15,7 @@ import com.nuguna.freview.customer.dto.response.CustomerProfilePhotoUpdateRespon
 import com.nuguna.freview.customer.dto.response.CustomerReviewRegisterResponseDTO;
 import com.nuguna.freview.customer.dto.response.CustomerTagsUpdateResponseDTO;
 import com.nuguna.freview.customer.exception.AlreadyExistNicknameException;
+import com.nuguna.freview.customer.exception.IllegalReviewException;
 import com.nuguna.freview.customer.mapper.CustomerBrandMapper;
 import com.nuguna.freview.customer.service.CustomerBrandService;
 import java.util.List;
@@ -36,9 +37,9 @@ public class CustomerBrandServiceImpl implements CustomerBrandService {
   @Override
   public CustomerNicknameUpdateResponseDTO updateCustomerNickname(
       CustomerNicknameUpdateRequestDTO customerNicknameUpdateRequestDTO) {
-
     String toNickname = customerNicknameUpdateRequestDTO.getToNickname();
     Long userSeq = customerNicknameUpdateRequestDTO.getUserSeq();
+    
     if (customerBrandMapper.checkNicknameExist(toNickname, userSeq)) {
       throw new AlreadyExistNicknameException("이미 존재하는 닉네임입니다.");
     }
@@ -51,6 +52,7 @@ public class CustomerBrandServiceImpl implements CustomerBrandService {
       CustomerAgeGroupUpdateRequestDTO customerAgeGroupUpdateRequestDTO) {
     Long userSeq = customerAgeGroupUpdateRequestDTO.getUserSeq();
     String toAgeGroup = customerAgeGroupUpdateRequestDTO.getToAgeGroup();
+
     customerBrandMapper.updateAgeGroup(userSeq, toAgeGroup);
     return new CustomerAgeGroupUpdateResponseDTO(toAgeGroup);
   }
@@ -60,6 +62,7 @@ public class CustomerBrandServiceImpl implements CustomerBrandService {
       CustomerProfilePhotoUpdateRequestDTO customerProfilePhotoUpdateRequestDTO) {
     Long userSeq = customerProfilePhotoUpdateRequestDTO.getUserSeq();
     String toProfilePhotoUrl = customerProfilePhotoUpdateRequestDTO.getToProfilePhotoUrl();
+
     customerBrandMapper.updateProfilePhotoUrl(userSeq, toProfilePhotoUrl);
     return new CustomerProfilePhotoUpdateResponseDTO(toProfilePhotoUrl);
   }
@@ -69,6 +72,7 @@ public class CustomerBrandServiceImpl implements CustomerBrandService {
       CustomerIntroduceUpdateRequestDTO customerIntroduceUpdateRequestDTO) {
     Long userSeq = customerIntroduceUpdateRequestDTO.getUserSeq();
     String toIntroduce = customerIntroduceUpdateRequestDTO.getToIntroduce();
+
     customerBrandMapper.updateIntroduce(userSeq, toIntroduce);
     return new CustomerIntroduceUpdateResponseDTO(toIntroduce);
   }
@@ -78,6 +82,7 @@ public class CustomerBrandServiceImpl implements CustomerBrandService {
       CustomerFoodTypesUpdateRequestDTO customerFoodTypesUpdateRequestDTO) {
     Long userSeq = customerFoodTypesUpdateRequestDTO.getUserSeq();
     List<String> toFoodTypes = customerFoodTypesUpdateRequestDTO.getToFoodTypes();
+
     customerBrandMapper.deleteFoodTypesByUserSeq(userSeq);
     if (toFoodTypes != null && !toFoodTypes.isEmpty()) {
       customerBrandMapper.insertFoodTypes(userSeq, toFoodTypes);
@@ -90,6 +95,7 @@ public class CustomerBrandServiceImpl implements CustomerBrandService {
       CustomerTagsUpdateRequestDTO customerTagsUpdateRequestDTO) {
     Long userSeq = customerTagsUpdateRequestDTO.getUserSeq();
     List<String> toTags = customerTagsUpdateRequestDTO.getToTags();
+
     customerBrandMapper.deleteTagsByUserSeq(userSeq);
     if (toTags != null && !toTags.isEmpty()) {
       customerBrandMapper.insertTags(userSeq, toTags);
@@ -100,6 +106,14 @@ public class CustomerBrandServiceImpl implements CustomerBrandService {
   @Override
   public CustomerReviewRegisterResponseDTO registerCustomerReview(
       CustomerReviewRegisterRequestDTO customerReviewRegisterRequestDTO) {
-    return null;
+    Long userSeq = customerReviewRegisterRequestDTO.getUserSeq(); // Customer의 Seq
+    Long reviewSeq = customerReviewRegisterRequestDTO.getReviewSeq();
+    String reviewUrl = customerReviewRegisterRequestDTO.getReviewUrl();
+
+    if (!customerBrandMapper.checkIsValidReview(userSeq, reviewSeq)) {
+      throw new IllegalReviewException("존재하지 않는 리뷰입니다.");
+    }
+    customerBrandMapper.registerReview(reviewSeq, reviewUrl);
+    return new CustomerReviewRegisterResponseDTO(reviewUrl);
   }
 }

--- a/src/main/java/com/nuguna/freview/customer/service/impl/CustomerBrandServiceImpl.java
+++ b/src/main/java/com/nuguna/freview/customer/service/impl/CustomerBrandServiceImpl.java
@@ -1,11 +1,28 @@
 package com.nuguna.freview.customer.service.impl;
 
+import com.nuguna.freview.customer.dto.request.CustomerAgeGroupUpdateRequestDTO;
+import com.nuguna.freview.customer.dto.request.CustomerFoodTypesUpdateRequestDTO;
+import com.nuguna.freview.customer.dto.request.CustomerIntroduceUpdateRequestDTO;
+import com.nuguna.freview.customer.dto.request.CustomerNicknameUpdateRequestDTO;
+import com.nuguna.freview.customer.dto.request.CustomerProfilePhotoUpdateRequestDTO;
+import com.nuguna.freview.customer.dto.request.CustomerReviewRegisterRequestDTO;
+import com.nuguna.freview.customer.dto.request.CustomerTagsUpdateRequestDTO;
+import com.nuguna.freview.customer.dto.response.CustomerAgeGroupUpdateResponseDTO;
+import com.nuguna.freview.customer.dto.response.CustomerFoodTypesUpdateResponseDTO;
+import com.nuguna.freview.customer.dto.response.CustomerIntroduceUpdateResponseDTO;
+import com.nuguna.freview.customer.dto.response.CustomerNicknameUpdateResponseDTO;
+import com.nuguna.freview.customer.dto.response.CustomerProfilePhotoUpdateResponseDTO;
+import com.nuguna.freview.customer.dto.response.CustomerReviewRegisterResponseDTO;
+import com.nuguna.freview.customer.dto.response.CustomerTagsUpdateResponseDTO;
+import com.nuguna.freview.customer.exception.AlreadyExistNicknameException;
 import com.nuguna.freview.customer.mapper.CustomerBrandMapper;
 import com.nuguna.freview.customer.service.CustomerBrandService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional
 public class CustomerBrandServiceImpl implements CustomerBrandService {
 
   private final CustomerBrandMapper customerBrandMapper;
@@ -13,5 +30,54 @@ public class CustomerBrandServiceImpl implements CustomerBrandService {
   @Autowired
   public CustomerBrandServiceImpl(CustomerBrandMapper customerBrandMapper) {
     this.customerBrandMapper = customerBrandMapper;
+  }
+
+  @Override
+  public CustomerNicknameUpdateResponseDTO updateCustomerNickname(
+      CustomerNicknameUpdateRequestDTO customerNicknameUpdateRequestDTO) {
+
+    String toNickname = customerNicknameUpdateRequestDTO.getToNickname();
+    Long userSeq = customerNicknameUpdateRequestDTO.getUserSeq();
+    if (customerBrandMapper.checkNicknameExist(toNickname, userSeq)) {
+      throw new AlreadyExistNicknameException("이미 존재하는 닉네임입니다.");
+    }
+    customerBrandMapper.updateNickname(userSeq, toNickname);
+    return new CustomerNicknameUpdateResponseDTO(toNickname);
+  }
+
+  @Override
+  public CustomerAgeGroupUpdateResponseDTO updateCustomerAgeGroup(
+      CustomerAgeGroupUpdateRequestDTO customerAgeGroupUpdateRequestDTO) {
+    return null;
+  }
+
+  @Override
+  public CustomerIntroduceUpdateResponseDTO updateCustomerIntroduce(
+      CustomerIntroduceUpdateRequestDTO customerIntroduceUpdateRequestDTO) {
+    return null;
+  }
+
+  @Override
+  public CustomerProfilePhotoUpdateResponseDTO updateCustomerPhotoUrl(
+      CustomerProfilePhotoUpdateRequestDTO customerProfilePhotoUpdateRequestDTO) {
+    return null;
+  }
+
+  @Override
+  public CustomerFoodTypesUpdateResponseDTO updateCustomerFoodTypes(
+      CustomerFoodTypesUpdateRequestDTO customerFoodTypesUpdateRequestDTO) {
+    return null;
+  }
+
+  @Override
+  public CustomerTagsUpdateResponseDTO updateCustomerTags(
+      CustomerTagsUpdateRequestDTO customerTagsUpdateRequestDTO) {
+    return null;
+  }
+
+  @Override
+  public CustomerReviewRegisterResponseDTO registerCustomerReview(
+      CustomerReviewRegisterRequestDTO customerReviewRegisterRequestDTO) {
+    return null;
   }
 }

--- a/src/main/java/com/nuguna/freview/customer/service/impl/CustomerBrandServiceImpl.java
+++ b/src/main/java/com/nuguna/freview/customer/service/impl/CustomerBrandServiceImpl.java
@@ -79,7 +79,9 @@ public class CustomerBrandServiceImpl implements CustomerBrandService {
     Long userSeq = customerFoodTypesUpdateRequestDTO.getUserSeq();
     List<String> toFoodTypes = customerFoodTypesUpdateRequestDTO.getToFoodTypes();
     customerBrandMapper.deleteFoodTypesByUserSeq(userSeq);
-    customerBrandMapper.insertFoodTypes(userSeq, toFoodTypes);
+    if (toFoodTypes != null && !toFoodTypes.isEmpty()) {
+      customerBrandMapper.insertFoodTypes(userSeq, toFoodTypes);
+    }
     return new CustomerFoodTypesUpdateResponseDTO(toFoodTypes);
   }
 
@@ -89,7 +91,9 @@ public class CustomerBrandServiceImpl implements CustomerBrandService {
     Long userSeq = customerTagsUpdateRequestDTO.getUserSeq();
     List<String> toTags = customerTagsUpdateRequestDTO.getToTags();
     customerBrandMapper.deleteTagsByUserSeq(userSeq);
-    customerBrandMapper.insertTags(userSeq, toTags);
+    if (toTags != null && !toTags.isEmpty()) {
+      customerBrandMapper.insertTags(userSeq, toTags);
+    }
     return new CustomerTagsUpdateResponseDTO(toTags);
   }
 

--- a/src/main/java/com/nuguna/freview/customer/service/impl/CustomerBrandServiceImpl.java
+++ b/src/main/java/com/nuguna/freview/customer/service/impl/CustomerBrandServiceImpl.java
@@ -1,0 +1,17 @@
+package com.nuguna.freview.customer.service.impl;
+
+import com.nuguna.freview.customer.mapper.CustomerBrandMapper;
+import com.nuguna.freview.customer.service.CustomerBrandService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CustomerBrandServiceImpl implements CustomerBrandService {
+
+  private final CustomerBrandMapper customerBrandMapper;
+
+  @Autowired
+  public CustomerBrandServiceImpl(CustomerBrandMapper customerBrandMapper) {
+    this.customerBrandMapper = customerBrandMapper;
+  }
+}

--- a/src/main/java/com/nuguna/freview/customer/service/impl/CustomerBrandServiceImpl.java
+++ b/src/main/java/com/nuguna/freview/customer/service/impl/CustomerBrandServiceImpl.java
@@ -86,7 +86,11 @@ public class CustomerBrandServiceImpl implements CustomerBrandService {
   @Override
   public CustomerTagsUpdateResponseDTO updateCustomerTags(
       CustomerTagsUpdateRequestDTO customerTagsUpdateRequestDTO) {
-    return null;
+    Long userSeq = customerTagsUpdateRequestDTO.getUserSeq();
+    List<String> toTags = customerTagsUpdateRequestDTO.getToTags();
+    customerBrandMapper.deleteTagsByUserSeq(userSeq);
+    customerBrandMapper.insertTags(userSeq, toTags);
+    return new CustomerTagsUpdateResponseDTO(toTags);
   }
 
   @Override

--- a/src/main/java/com/nuguna/freview/customer/validation/AgeGroupValidator.java
+++ b/src/main/java/com/nuguna/freview/customer/validation/AgeGroupValidator.java
@@ -1,0 +1,22 @@
+package com.nuguna.freview.customer.validation;
+
+import com.nuguna.freview.customer.validation.annotation.ValidAgeGroup;
+import java.util.Arrays;
+import java.util.List;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class AgeGroupValidator implements ConstraintValidator<ValidAgeGroup, String> {
+
+  private final List<String> validAgeGroups = Arrays.asList("10대", "20대", "30대", "40대", "50대",
+      "60대", "70대", "80대", "90대");
+
+  @Override
+  public void initialize(ValidAgeGroup constraintAnnotation) {
+  }
+
+  @Override
+  public boolean isValid(String value, ConstraintValidatorContext context) {
+    return validAgeGroups.contains(value);
+  }
+}

--- a/src/main/java/com/nuguna/freview/customer/validation/CustomerTagsValidator.java
+++ b/src/main/java/com/nuguna/freview/customer/validation/CustomerTagsValidator.java
@@ -1,0 +1,26 @@
+package com.nuguna.freview.customer.validation;
+
+
+import com.nuguna.freview.customer.validation.annotation.ValidCustomerTags;
+import java.util.Arrays;
+import java.util.List;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class CustomerTagsValidator implements ConstraintValidator<ValidCustomerTags, List<String>> {
+
+  private static final List<String> ALLOWED_TAGS = Arrays.asList("초식", "육식", "맛집블로거", "정성리뷰어");
+
+  @Override
+  public boolean isValid(List<String> tags, ConstraintValidatorContext context) {
+    if (tags == null) {
+      return true; // null is valid, use @NotNull if needed
+    }
+    for (String tag : tags) {
+      if (!ALLOWED_TAGS.contains(tag)) {
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/src/main/java/com/nuguna/freview/customer/validation/FoodTypeValidator.java
+++ b/src/main/java/com/nuguna/freview/customer/validation/FoodTypeValidator.java
@@ -1,0 +1,34 @@
+package com.nuguna.freview.customer.validation;
+
+import com.nuguna.freview.customer.validation.annotation.ValidFoodTypes;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class FoodTypeValidator implements ConstraintValidator<ValidFoodTypes, List<String>> {
+
+  private final Set<String> validFoodTypes = new HashSet<>(Arrays.asList(
+      "국밥", "돈까스", "족발", "막창", "피자", "파스타", "햄버거", "스테이크", "마라탕", "짜장면", "짬뽕",
+      "탕수육", "텐동", "초밥", "규동", "라멘", "빵", "케이크", "쿠키", "샌드위치", "커피", "커리", "쌀국수", "기타"
+  ));
+
+  @Override
+  public void initialize(ValidFoodTypes constraintAnnotation) {
+  }
+
+  @Override
+  public boolean isValid(List<String> value, ConstraintValidatorContext context) {
+    if (value == null) {
+      return true;
+    }
+    for (String foodType : value) {
+      if (!validFoodTypes.contains(foodType)) {
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/src/main/java/com/nuguna/freview/customer/validation/annotation/ValidAgeGroup.java
+++ b/src/main/java/com/nuguna/freview/customer/validation/annotation/ValidAgeGroup.java
@@ -1,0 +1,21 @@
+package com.nuguna.freview.customer.validation.annotation;
+
+import com.nuguna.freview.customer.validation.AgeGroupValidator;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+@Constraint(validatedBy = AgeGroupValidator.class)
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.ANNOTATION_TYPE, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidAgeGroup {
+
+  String message() default "유효하지 않은 연령대입니다.";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/nuguna/freview/customer/validation/annotation/ValidCustomerTags.java
+++ b/src/main/java/com/nuguna/freview/customer/validation/annotation/ValidCustomerTags.java
@@ -1,0 +1,21 @@
+package com.nuguna.freview.customer.validation.annotation;
+
+import com.nuguna.freview.customer.validation.CustomerTagsValidator;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+@Constraint(validatedBy = CustomerTagsValidator.class)
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidCustomerTags {
+
+  String message() default "유효하지 않은 체험단 태그입니다.";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/nuguna/freview/customer/validation/annotation/ValidFoodTypes.java
+++ b/src/main/java/com/nuguna/freview/customer/validation/annotation/ValidFoodTypes.java
@@ -1,0 +1,21 @@
+package com.nuguna.freview.customer.validation.annotation;
+
+import com.nuguna.freview.customer.validation.FoodTypeValidator;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+@Constraint(validatedBy = FoodTypeValidator.class)
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.ANNOTATION_TYPE, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidFoodTypes {
+
+  String message() default "유효하지 않은 활동 분야입니다.";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/nuguna/freview/global/util/SendMailUtil.java
+++ b/src/main/java/com/nuguna/freview/global/util/SendMailUtil.java
@@ -1,0 +1,72 @@
+package com.nuguna.freview.global.util;
+
+import java.util.Properties;
+import javax.mail.Authenticator;
+import javax.mail.Message;
+import javax.mail.PasswordAuthentication;
+import javax.mail.Session;
+import javax.mail.Transport;
+import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeMessage;
+
+public class SendMailUtil {
+
+  final private String ENCODING = "";
+  final private String PORT = "";
+  final private String SMTPHOST = "";
+  final private String userName = "";
+  final private String password = "";
+
+
+  public Session setting(Properties props) {
+    Session session = null;
+
+    try {
+      props.put("mail.transport.protocol", "smtp");
+      props.put("mail.smtp.host", SMTPHOST);
+      props.put("mail.smt.port", PORT);
+      props.put("mail.smtp.auth", true);
+      props.put("mail.smtp.ssl.enable", true);
+      props.put("mail.smtp.ssl.trust", SMTPHOST);
+      props.put("mail.smtp.starttls.required", true);
+      props.put("mail.smtp.starttls.enable", true);
+      props.put("mail.smtp.ssl.protocols", "TLSv1.2");
+
+      props.put("mail.smtp.quit-wait", "false");
+      props.put("mail.smtp.socketFactory.port", PORT);
+      props.put("mail.smtp.socketFactory.class", "javax.net.ssl.SSLSocketFactory");
+      props.put("mail.smtp.socketFactory.fallback", "false");
+
+      session = Session.getInstance(props, new Authenticator() {
+        @Override
+        protected PasswordAuthentication getPasswordAuthentication() {
+          return new PasswordAuthentication(userName, password);
+        }
+      });
+    } catch (Exception e) {
+      System.out.println("Session setting 실패");
+      e.printStackTrace();
+    }
+
+    return session;
+  }
+
+  public void goMail(Session session, String title, String content, String TO) {
+
+    Message msg = new MimeMessage(session);
+
+    try {
+      msg.setFrom(new InternetAddress("rlagkfka9611@google.com", "FReview", ENCODING));
+      msg.addRecipient(Message.RecipientType.TO, new InternetAddress(TO));
+      msg.setSubject(title);
+      msg.setContent(content, "text/html; charset=utf-8");
+
+      Transport.send(msg);
+      System.out.println("메일 보내기 성공");
+    } catch (Exception e) {
+      e.printStackTrace();
+      System.out.println("메일 보내시 실패");
+    }
+  }
+
+}

--- a/src/main/java/com/nuguna/freview/global/util/ShaUtil.java
+++ b/src/main/java/com/nuguna/freview/global/util/ShaUtil.java
@@ -1,0 +1,11 @@
+package com.nuguna.freview.global.util;
+
+import com.google.common.hash.Hashing;
+import java.nio.charset.StandardCharsets;
+
+public class ShaUtil {
+
+  public static String sha256Encoding(String purePw) {
+    return Hashing.sha256().hashString(purePw, StandardCharsets.UTF_8).toString();
+  }
+}

--- a/src/main/resources/mappers/customer/customer-brand-map.xml
+++ b/src/main/resources/mappers/customer/customer-brand-map.xml
@@ -23,4 +23,10 @@
     where seq = #{userSeq}
   </update>
 
+  <update id="updateProfilePhotoUrl">
+    update user
+    set profile_photo_url = #{toProfilePhotoUrl}
+    where seq = #{userSeq}
+  </update>
+
 </mapper>

--- a/src/main/resources/mappers/customer/customer-brand-map.xml
+++ b/src/main/resources/mappers/customer/customer-brand-map.xml
@@ -46,10 +46,29 @@
     SELECT
     #{userSeq}, seq
     FROM
-    FOOD_TYPE
+    food_type
     WHERE
     dish IN
     <foreach item="item" index="index" collection="toFoodTypes" open="(" separator="," close=")">
+      #{item}
+    </foreach>
+  </insert>
+
+  <delete id="deleteTagsByUserSeq">
+    delete
+    from user_tag
+    where user_seq = #{userSeq}
+  </delete>
+
+  <insert id="insertTags">
+    INSERT INTO user_tag (user_seq, tag_seq)
+    SELECT
+    #{userSeq}, seq
+    FROM
+    tag
+    WHERE
+    name IN
+    <foreach item="item" index="index" collection="toTags" open="(" separator="," close=")">
       #{item}
     </foreach>
   </insert>

--- a/src/main/resources/mappers/customer/customer-brand-map.xml
+++ b/src/main/resources/mappers/customer/customer-brand-map.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.nuguna.freview.customer.mapper.CustomerBrandMapper">
+
+</mapper>

--- a/src/main/resources/mappers/customer/customer-brand-map.xml
+++ b/src/main/resources/mappers/customer/customer-brand-map.xml
@@ -42,13 +42,13 @@
   </delete>
 
   <insert id="insertFoodTypes">
-    INSERT INTO user_food_type (user_seq, food_type_seq)
-    SELECT
+    insert into user_food_type (user_seq, food_type_seq)
+    select
     #{userSeq}, seq
-    FROM
+    from
     food_type
-    WHERE
-    dish IN
+    where
+    dish in
     <foreach item="item" index="index" collection="toFoodTypes" open="(" separator="," close=")">
       #{item}
     </foreach>
@@ -61,16 +61,30 @@
   </delete>
 
   <insert id="insertTags">
-    INSERT INTO user_tag (user_seq, tag_seq)
-    SELECT
+    insert into user_tag (user_seq, tag_seq)
+    select
     #{userSeq}, seq
-    FROM
+    from
     tag
-    WHERE
-    name IN
+    where
+    name in
     <foreach item="item" index="index" collection="toTags" open="(" separator="," close=")">
       #{item}
     </foreach>
   </insert>
+
+  <select id="checkIsValidReview" resultType="Boolean">
+    select count(1) > 0
+    from review
+    where seq = #{reviewSeq}
+      and customer_seq = #{userSeq}
+  </select>
+
+  <update id="registerReview">
+    update review
+    set url    = #{reviewUrl},
+        status = 'WRITTEN'
+    where seq = #{reviewSeq}
+  </update>
 
 </mapper>

--- a/src/main/resources/mappers/customer/customer-brand-map.xml
+++ b/src/main/resources/mappers/customer/customer-brand-map.xml
@@ -4,4 +4,17 @@
 
 <mapper namespace="com.nuguna.freview.customer.mapper.CustomerBrandMapper">
 
+  <select id="checkNicknameExist" resultType="Boolean">
+    select count(1) > 0
+    from user
+    where nickname = #{toNickname}
+      and seq != #{userSeq}
+  </select>
+
+  <update id="updateNickname">
+    update user
+    set nickname = #{toNickname}
+    where seq = #{userSeq}
+  </update>
+
 </mapper>

--- a/src/main/resources/mappers/customer/customer-brand-map.xml
+++ b/src/main/resources/mappers/customer/customer-brand-map.xml
@@ -4,6 +4,12 @@
 
 <mapper namespace="com.nuguna.freview.customer.mapper.CustomerBrandMapper">
 
+  <update id="updateProfilePhotoUrl">
+    update user
+    set profile_photo_url = #{toProfilePhotoUrl}
+    where seq = #{userSeq}
+  </update>
+
   <select id="checkNicknameExist" resultType="Boolean">
     select count(1) > 0
     from user
@@ -22,10 +28,10 @@
     set age_group = #{toAgeGroup}
     where seq = #{userSeq}
   </update>
-
-  <update id="updateProfilePhotoUrl">
+  
+  <update id="updateIntroduce">
     update user
-    set profile_photo_url = #{toProfilePhotoUrl}
+    set introduce = #{toIntroduce}
     where seq = #{userSeq}
   </update>
 

--- a/src/main/resources/mappers/customer/customer-brand-map.xml
+++ b/src/main/resources/mappers/customer/customer-brand-map.xml
@@ -28,11 +28,30 @@
     set age_group = #{toAgeGroup}
     where seq = #{userSeq}
   </update>
-  
+
   <update id="updateIntroduce">
     update user
     set introduce = #{toIntroduce}
     where seq = #{userSeq}
   </update>
+
+  <delete id="deleteFoodTypesByUserSeq">
+    delete
+    from user_food_type
+    where user_seq = #{userSeq}
+  </delete>
+
+  <insert id="insertFoodTypes">
+    INSERT INTO user_food_type (user_seq, food_type_seq)
+    SELECT
+    #{userSeq}, seq
+    FROM
+    FOOD_TYPE
+    WHERE
+    dish IN
+    <foreach item="item" index="index" collection="toFoodTypes" open="(" separator="," close=")">
+      #{item}
+    </foreach>
+  </insert>
 
 </mapper>

--- a/src/main/resources/mappers/customer/customer-brand-map.xml
+++ b/src/main/resources/mappers/customer/customer-brand-map.xml
@@ -17,4 +17,10 @@
     where seq = #{userSeq}
   </update>
 
+  <update id="updateAgeGroup">
+    update user
+    set age_group = #{toAgeGroup}
+    where seq = #{userSeq}
+  </update>
+
 </mapper>

--- a/src/main/webapp/customer-my-brand-info.jsp
+++ b/src/main/webapp/customer-my-brand-info.jsp
@@ -15,6 +15,10 @@
       .selected-option {
         background-color: lightgreen; /* 연초록색으로 선택된 옵션 표시 */
       }
+
+      #food-type-select-message {
+        margin-bottom: 5px;
+      }
     </style>
 
     <style>
@@ -414,14 +418,46 @@
                                 <div class="col-lg-3 col-md-4 label">활동 분야</div>
                                 <div class="col-lg-8 col-md-6">
                                     <select id="food-type-select" class="form-select" multiple
-                                            size="6" disabled>
-                                        <option value="한식">한식</option>
-                                        <option value="양식">양식</option>
-                                        <option value="중식">중식</option>
-                                        <option value="일식">일식</option>
-                                        <option value="빵&베이커리">빵&베이커리</option>
-                                        <option value="기타">기타</option>
+                                            size="5" disabled>
+                                        <option value="국밥" data-custom-color="orange">국밥</option>
+                                        <option value="돈까스" data-custom-color="orange">돈까스</option>
+                                        <option value="족발" data-custom-color="orange">족발</option>
+                                        <option value="막창" data-custom-color="orange">막창</option>
+                                        <option value="피자" data-custom-color="mediumvioletred">피자
+                                        </option>
+                                        <option value="파스타" data-custom-color="mediumvioletred">
+                                            파스타
+                                        </option>
+                                        <option value="햄버거" data-custom-color="mediumvioletred">
+                                            햄버거
+                                        </option>
+                                        <option value="스테이크" data-custom-color="mediumvioletred">
+                                            스테이크
+                                        </option>
+                                        <option value="마라탕" data-custom-color="saddlebrown">마라탕
+                                        </option>
+                                        <option value="짜장면" data-custom-color="saddlebrown">짜장면
+                                        </option>
+                                        <option value="짬뽕" data-custom-color="saddlebrown">짬뽕
+                                        </option>
+                                        <option value="탕수육" data-custom-color="saddlebrown">탕수육
+                                        </option>
+                                        <option value="텐동" data-custom-color="olivedrab">텐동</option>
+                                        <option value="초밥" data-custom-color="olivedrab">초밥</option>
+                                        <option value="규동" data-custom-color="olivedrab">규동</option>
+                                        <option value="라멘" data-custom-color="olivedrab">라멘</option>
+                                        <option value="빵" data-custom-color="sienna">빵</option>
+                                        <option value="케이크" data-custom-color="sienna">케이크</option>
+                                        <option value="쿠키" data-custom-color="sienna">쿠키</option>
+                                        <option value="샌드위치" data-custom-color="sienna">샌드위치
+                                        </option>
+                                        <option value="커피" data-custom-color="sienna">커피</option>
+                                        <option value="커리" data-custom-color="green">커리</option>
+                                        <option value="쌀국수" data-custom-color="green">쌀국수</option>
+                                        <option value="기타" data-custom-color="green">기타</option>
                                     </select>
+                                    <p id="food-type-select-message" class="text-primary"
+                                       style="font-size: 14px;"></p>
                                 </div>
                                 <div class="col-lg-1 col-md-2">
                                     <button id="food-type-update-btn" type="button"
@@ -437,24 +473,51 @@
                                     </button>
                                 </div>
                             </div>
-                            <script>
-                              var selectedFoodTypes = ${brandInfo.foodTypes};
 
-                              function initializeFoodTypeSelect() {
-                                var foodTypeSelect = $('#food-type-select');
-                                foodTypeSelect.find('option').each(function () {
-                                  if (selectedFoodTypes.includes($(this).val())) {
-                                    $(this).prop('selected', true);
-                                    $(this).addClass('selected-option');
-                                  } else {
-                                    $(this).prop('selected', false);
-                                    $(this).removeClass('selected-option');
+                            <script>
+                              $(document).ready(function () {
+                                $('#food-type-select').select2({
+                                  width: '100%',
+                                  templateSelection: function (option) {
+                                    var color = $(option.element).data('custom-color');
+                                    return $('<span style="color: ' + color + '">' + option.text
+                                        + '</span>');
                                   }
                                 });
-                              }
 
-                              $(document).ready(function () {
+                                var selectedFoodTypes = ${brandInfo.foodTypes};
+
+                                function initializeFoodTypeSelect() {
+                                  var foodTypeSelect = $('#food-type-select');
+                                  foodTypeSelect.val(selectedFoodTypes).trigger('change');
+
+                                  updateFoodTypeMessage();
+                                }
+
+                                function updateFoodTypeMessage() {
+                                  var selectedOptions = $('#food-type-select').val();
+                                  var messageElement = $('#food-type-select-message');
+
+                                  if (selectedOptions === null || selectedOptions.length === 0) {
+                                    messageElement.text('아직 선택한 활동 분야가 없어요.');
+                                  } else {
+                                    messageElement.text('');
+                                  }
+                                }
+
                                 initializeFoodTypeSelect();
+
+                                $('#food-type-select').on('select2:select', function (e) {
+                                  var selectedOptions = $(this).val();
+                                  if (selectedOptions.length > 5) {
+                                    var $element = $(e.params.data.element);
+                                    $element.prop('selected', false);
+                                    $(this).trigger('change');
+                                    alert('활동 분야는 최대 5개까지만 선택할 수 있습니다.');
+                                  } else {
+                                    updateFoodTypeMessage();
+                                  }
+                                });
 
                                 $("#food-type-update-btn").click(function () {
                                   $("#food-type-update-btn").hide();
@@ -472,19 +535,14 @@
                                 });
 
                                 $('#food-type-select').on('change', function () {
-                                  $('#food-type-select option').each(function () {
-                                    if ($(this).is(':selected')) {
-                                      $(this).addClass('selected-option');
-                                    } else {
-                                      $(this).removeClass('selected-option');
-                                    }
-                                  });
+                                  $(this).find('option:selected').addClass('selected-option');
+                                  $(this).find('option:not(:selected)').removeClass(
+                                      'selected-option');
+                                  updateFoodTypeMessage();
                                 });
 
                                 $("#food-type-submit-btn").click(function () {
-                                  var selectedFoodTypes = Array.from(
-                                      $("#food-type-select option:selected")).map(
-                                      option => option.value);
+                                  var selectedFoodTypes = $('#food-type-select').val();
 
                                   $.ajax({
                                     url: '<%=request.getContextPath()%>/api/my-brand/food-type',
@@ -495,36 +553,20 @@
                                       'toFoodTypes': selectedFoodTypes
                                     }),
                                     success: function (response) {
-                                      var foodTypesFromServer = response.item;
-
-                                      $("#food-type-submit-btn").hide();
-                                      $("#food-type-cancel-btn").hide();
-                                      $("#food-type-update-btn").show();
-                                      $('#food-type-select').prop('disabled', true);
-
-                                      var foodTypeSelect = document.getElementById(
-                                          'food-type-select');
-                                      var currentOptions = Array.from(foodTypeSelect.options).map(
-                                          option => option.value);
-                                      var newOptions = new Set(
-                                          [...currentOptions, ...foodTypesFromServer]);
-
-                                      foodTypeSelect.innerHTML = '';
-
-                                      newOptions.forEach(function (foodType) {
-                                        var option = document.createElement('option');
-                                        option.value = foodType;
-                                        option.text = foodType;
-                                        if (foodTypesFromServer.includes(foodType)) {
-                                          option.selected = true;
-                                          option.classList.add('selected-option');
-                                        }
-                                        foodTypeSelect.appendChild(option);
-                                      });
                                       alert('활동 분야 변경에 성공하였습니다.');
+                                      $('#food-type-select').prop('disabled', true).select2({
+                                        width: '100%',
+                                        templateSelection: function (option) {
+                                          var color = $(option.element).data('custom-color');
+                                          return $(
+                                              '<span style="color: ' + color + '">' + option.text
+                                              + '</span>');
+                                        }
+                                      });
+                                      $('#food-type-submit-btn, #food-type-cancel-btn').hide();
+                                      $('#food-type-update-btn').show();
                                     },
-                                    error: function (error) {
-                                      console.log(error);
+                                    error: function (err) {
                                       alert('활동 분야 변경에 실패하였습니다.');
                                     }
                                   });

--- a/src/main/webapp/customer-my-brand-info.jsp
+++ b/src/main/webapp/customer-my-brand-info.jsp
@@ -605,7 +605,6 @@
                             </div>
 
                             <script>
-
                               $(document).ready(function () {
                                 $('#tag-select').select2({
                                   width: '100%',
@@ -621,25 +620,40 @@
                                 function initializeTagSelect() {
                                   var tagSelect = $('#tag-select');
                                   tagSelect.val(selectedTags).trigger('change');
+                                  updateTagMessage();
+                                }
 
-                                  // Display message if selectedTags is empty
-                                  if (selectedTags.length === 0) {
-                                    $('#tag-select-message').text('아직 선택한 태그가 없어요.');
+                                function updateTagMessage() {
+                                  var selectedOptions = $('#tag-select').val();
+                                  var messageElement = $('#tag-select-message');
+
+                                  if (selectedOptions === null || selectedOptions.length === 0) {
+                                    messageElement.text('아직 선택한 태그가 없어요.');
                                   } else {
-                                    $('#tag-select-message').text('');
+                                    messageElement.text('');
                                   }
                                 }
 
                                 initializeTagSelect();
 
-                                $('#tag-select').on('select2:select', function (e) {
-                                  var selectedOptions = $(this).val();
-                                  if (selectedOptions.length > 2) {
-                                    var $element = $(e.params.data.element);
-                                    $element.prop("selected", false);
-                                    $(this).trigger('change');
-                                    alert('태그는 2개까지만 선택할 수 있습니다');
-                                  }
+                                $('#tag-select').on('select2:select',
+                                    function (e) {
+                                      var selectedOptions = $(this).val();
+                                      if (selectedOptions.length > 2) {
+                                        var $element = $(e.params.data.element);
+                                        $element.prop("selected", false);
+                                        $(this).trigger('change');
+                                        alert('태그는 2개까지만 선택할 수 있습니다');
+                                      } else {
+                                        updateTagMessage();
+                                      }
+                                    });
+
+                                $('#tag-select').on('change', function () {
+                                  $(this).find('option:selected').addClass('selected-option');
+                                  $(this).find('option:not(:selected)').removeClass(
+                                      'selected-option');
+                                  updateTagMessage();
                                 });
 
                                 $("#tag-update-btn").click(function () {
@@ -694,6 +708,7 @@
                                       });
                                       $('#tag-submit-btn, #tag-cancel-btn').hide();
                                       $('#tag-update-btn').show();
+                                      updateTagMessage();
                                     },
                                     error: function (err) {
                                       alert('태그 변경에 실패하였습니다.');
@@ -701,11 +716,7 @@
                                   });
                                 });
 
-                                $('#tag-select').on('change', function () {
-                                  $(this).find('option:selected').addClass('selected-option');
-                                  $(this).find('option:not(:selected)').removeClass(
-                                      'selected-option');
-                                });
+                                initializeTagSelect();
                               });
                             </script>
 </main><!-- End #main -->

--- a/src/main/webapp/customer-my-brand-info.jsp
+++ b/src/main/webapp/customer-my-brand-info.jsp
@@ -37,6 +37,7 @@
         background-color: #e9ecef;
         opacity: 1;
       }
+
     </style>
 
     <meta charset="utf-8">
@@ -49,7 +50,7 @@
     <!-- Favicons -->
     <link href="/assets/img/favicon.png" rel="icon">
     <link href="/assets/img/apple-touch-icon.png" rel="apple-touch-icon">
-  
+
     <!-- Google Fonts -->
     <link href="https://fonts.gstatic.com" rel="preconnect">
     <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,300i,400,400i,600,600i,700,700i|Nunito:300,300i,400,400i,600,600i,700,700i|Poppins:300,300i,400,400i,500,500i,600,600i,700,700i"
@@ -78,6 +79,12 @@
 
     <link rel="stylesheet"
           href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+
+    <!--Select2 Css, JS -->
+    <link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css"
+          rel="stylesheet"/>
+    <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
+
 
     <!-- =======================================================
     * Template Name: NiceAdmin
@@ -175,8 +182,6 @@
 
                         <div class="tab-pane fade show active profile-overview"
                              id="profile-overview">
-
-                            <h5 class="card-title">Profile Details</h5>
 
                             <!-- 소개 -->
                             <div class="row">
@@ -434,6 +439,7 @@
                             </div>
                             <script>
                               var selectedFoodTypes = ${brandInfo.foodTypes};
+
                               function initializeFoodTypeSelect() {
                                 var foodTypeSelect = $('#food-type-select');
                                 foodTypeSelect.find('option').each(function () {
@@ -525,16 +531,21 @@
                                 });
                               });
                             </script>
-                            <!-- 태그들 보여주기/등록하기 -->
+
                             <div class="row">
                                 <div class="col-lg-3 col-md-4 label">태그</div>
                                 <div class="col-lg-8 col-md-6">
-                                    <select id="tag-select" class="form-select" multiple size="3"
+                                    <select id="tag-select" class="form-select" multiple size="2"
                                             disabled>
-                                        <option value="초식">초식</option>
-                                        <option value="육식">육식</option>
-                                        <option value="빵빵이">빵빵이</option>
+                                        <option value="초식" data-custom-color="green">초식</option>
+                                        <option value="육식" data-custom-color="indianred">육식</option>
+                                        <option value="맛집블로거" data-custom-color="blue">맛집블로거
+                                        </option>
+                                        <option value="정성리뷰어" data-custom-color="orange">정성리뷰어
+                                        </option>
                                     </select>
+                                    <p id="tag-select-message" class="text-primary"
+                                       style="font-size: 14px;"></p>
                                 </div>
                                 <div class="col-lg-1 col-md-2">
                                     <button id="tag-update-btn" type="button"
@@ -552,60 +563,94 @@
                             </div>
 
                             <script>
+
                               $(document).ready(function () {
+                                $('#tag-select').select2({
+                                  width: '100%',
+                                  templateSelection: function (option) {
+                                    var color = $(option.element).data('custom-color');
+                                    return $('<span style="color: ' + color + '">' + option.text
+                                        + '</span>');
+                                  }
+                                });
+
                                 var selectedTags = ${brandInfo.tagInfos};
-                                <%--'{\"tagInfos\" : \"${brandInfo.tagInfos}\"}');--%>
-                                <%--'<%=gson.toJson(brandInfo.getTagInfos())%>'--%>
 
                                 function initializeTagSelect() {
                                   var tagSelect = $('#tag-select');
-                                  tagSelect.find('option').each(function () {
-                                    if (selectedTags.includes($(this).val())) {
-                                      $(this).prop('selected', true);
-                                      $(this).addClass('selected-option');
-                                    } else {
-                                      $(this).prop('selected', false);
-                                      $(this).removeClass('selected-option');
-                                    }
-                                  });
+                                  tagSelect.val(selectedTags).trigger('change');
+
+                                  // Display message if selectedTags is empty
+                                  if (selectedTags.length === 0) {
+                                    $('#tag-select-message').text('아직 선택한 태그가 없어요.');
+                                  } else {
+                                    $('#tag-select-message').text('');
+                                  }
                                 }
 
                                 initializeTagSelect();
 
+                                $('#tag-select').on('select2:select', function (e) {
+                                  var selectedOptions = $(this).val();
+                                  if (selectedOptions.length > 2) {
+                                    var $element = $(e.params.data.element);
+                                    $element.prop("selected", false);
+                                    $(this).trigger('change');
+                                    alert('태그는 2개까지만 선택할 수 있습니다');
+                                  }
+                                });
+
                                 $("#tag-update-btn").click(function () {
-                                  $("#tag-update-btn").hide();
-                                  $("#tag-cancel-btn").show();
-                                  $("#tag-submit-btn").show();
-                                  $('#tag-select').prop('disabled', false);
+                                  $(this).hide();
+                                  $("#tag-cancel-btn, #tag-submit-btn").show();
+                                  $('#tag-select').prop('disabled', false).select2({
+                                    width: '100%',
+                                    templateSelection: function (option) {
+                                      var color = $(option.element).data('custom-color');
+                                      return $('<span style="color: ' + color + '">' + option.text
+                                          + '</span>');
+                                    }
+                                  });
                                 });
 
                                 $('#tag-cancel-btn').click(function () {
-                                  $('#tag-cancel-btn').hide();
-                                  $('#tag-submit-btn').hide();
-                                  $('#tag-update-btn').show();
-                                  $('#tag-select').prop('disabled', true);
+                                  $(this).hide();
+                                  $("#tag-submit-btn").hide();
+                                  $("#tag-update-btn").show();
+                                  $('#tag-select').prop('disabled', true).select2({
+                                    width: '100%',
+                                    templateSelection: function (option) {
+                                      var color = $(option.element).data('custom-color');
+                                      return $('<span style="color: ' + color + '">' + option.text
+                                          + '</span>');
+                                    }
+                                  });
                                   initializeTagSelect();
                                 });
 
                                 $('#tag-submit-btn').click(function () {
-                                  var selectedTags = [];
-                                  $('#tag-select option:selected').each(function () {
-                                    selectedTags.push($(this).val());
-                                  });
+                                  var selectedTags = $('#tag-select').val();
 
                                   $.ajax({
                                     url: '<%=request.getContextPath()%>/api/my-brand/tag',
                                     method: 'POST',
+                                    contentType: 'application/json',
                                     data: JSON.stringify({
                                       'userSeq': ${userSeq},
                                       'toTags': selectedTags
                                     }),
                                     success: function (response) {
-                                      console.log(response.item);
                                       alert('태그 변경에 성공하였습니다.');
-                                      $('#tag-select').prop('disabled', true);
-                                      $('#tag-submit-btn').hide();
-                                      $('#tag-cancel-btn').hide();
+                                      $('#tag-select').prop('disabled', true).select2({
+                                        width: '100%',
+                                        templateSelection: function (option) {
+                                          var color = $(option.element).data('custom-color');
+                                          return $(
+                                              '<span style="color: ' + color + '">' + option.text
+                                              + '</span>');
+                                        }
+                                      });
+                                      $('#tag-submit-btn, #tag-cancel-btn').hide();
                                       $('#tag-update-btn').show();
                                     },
                                     error: function (err) {
@@ -615,13 +660,9 @@
                                 });
 
                                 $('#tag-select').on('change', function () {
-                                  $('#tag-select option').each(function () {
-                                    if ($(this).is(':selected')) {
-                                      $(this).addClass('selected-option');
-                                    } else {
-                                      $(this).removeClass('selected-option');
-                                    }
-                                  });
+                                  $(this).find('option:selected').addClass('selected-option');
+                                  $(this).find('option:not(:selected)').removeClass(
+                                      'selected-option');
                                 });
                               });
                             </script>


### PR DESCRIPTION
### [이번 PR에서 프로세스 설계서 상 구현한 API 목록]

<img width="636" alt="스크린샷 2024-07-17 오후 8 57 57" src="https://github.com/user-attachments/assets/fc36036e-7d13-4dae-89d0-b1a1dfb1fc89">



### [전체적인 체험단 브랜딩 수정 페이지 뷰]

<img width="1469" alt="스크린샷 2024-07-17 오후 9 01 03" src="https://github.com/user-attachments/assets/cecdbc8f-8966-49bf-8a93-6f168928822e">



### [활동 분야, 태그 수정 뷰]

1) 아무것도 선택하지 않았을 떄
<img width="655" alt="스크린샷 2024-07-17 오후 9 01 57" src="https://github.com/user-attachments/assets/0fa9a895-d1d4-45c5-8756-8931ba712e53">


2) 활동 분야 선택 시
<img width="704" alt="스크린샷 2024-07-17 오후 9 02 20" src="https://github.com/user-attachments/assets/05775145-2630-4550-ac2d-154262e10a86">


3) 예외 케이스 - 활동 분야 5개 이상 선택 시

<img width="715" alt="스크린샷 2024-07-17 오후 9 02 39" src="https://github.com/user-attachments/assets/3ea7c7c7-a184-40b6-93d4-6ee033dcab69">


4) 태그 선택 시

<img width="706" alt="스크린샷 2024-07-17 오후 9 05 03" src="https://github.com/user-attachments/assets/150fd5e5-f217-4460-9b8e-763be58b4bc4">


5) 예외 케이스 - 태그 2개 이상 선택 시

<img width="733" alt="스크린샷 2024-07-17 오후 9 05 31" src="https://github.com/user-attachments/assets/b00443e5-5bf0-44ad-aac9-f56d689e7b00">
