### PR TITLE
[feat-admin] 유저 별 노쇼 횟수 누계 시스템 구현

### DIFF
--- a/src/main/java/com/nuguna/freview/admin/dto/ExperienceLogDTO.java
+++ b/src/main/java/com/nuguna/freview/admin/dto/ExperienceLogDTO.java
@@ -1,0 +1,13 @@
+package com.nuguna.freview.admin.dto;
+
+import lombok.Getter;
+
+@Getter
+public class ExperienceLogDTO {
+
+  private Long seq;
+  private Long fromUserSeq;
+  private Long toUserSeq;
+  private Long fromPostSeq;
+  private String status;
+}

--- a/src/main/java/com/nuguna/freview/admin/dto/response/CustomerInfoDTO.java
+++ b/src/main/java/com/nuguna/freview/admin/dto/response/CustomerInfoDTO.java
@@ -17,4 +17,5 @@ public class CustomerInfoDTO {
   private String nickname;
   private String email;
   private Timestamp createdAt;
+  private int totalNoshow;
 }

--- a/src/main/java/com/nuguna/freview/admin/mapper/ExperienceMapper.java
+++ b/src/main/java/com/nuguna/freview/admin/mapper/ExperienceMapper.java
@@ -1,0 +1,11 @@
+package com.nuguna.freview.admin.mapper;
+
+import com.nuguna.freview.admin.dto.ExperienceLogDTO;
+import java.util.List;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface ExperienceMapper {
+
+  List<ExperienceLogDTO> selectExperiencesToNoShow(Long lastProcessedSeq);
+}

--- a/src/main/java/com/nuguna/freview/admin/mapper/ExperiencePostProcessingLogMapper.java
+++ b/src/main/java/com/nuguna/freview/admin/mapper/ExperiencePostProcessingLogMapper.java
@@ -1,0 +1,10 @@
+package com.nuguna.freview.admin.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface ExperiencePostProcessingLogMapper {
+
+  void updateLastProcessedSeq(Long seq);
+  Long getLastProcessedSeq();
+}

--- a/src/main/java/com/nuguna/freview/admin/mapper/LikeAccumulationMapper.java
+++ b/src/main/java/com/nuguna/freview/admin/mapper/LikeAccumulationMapper.java
@@ -6,7 +6,7 @@ import org.apache.ibatis.annotations.Mapper;
 @Mapper
 public interface LikeAccumulationMapper {
 
-  LikeAccumulationVO findByPostSeq(Long postSeq);
+  LikeAccumulationVO getByPostSeq(Long postSeq);
   void insert(LikeAccumulationVO accumulation);
   void update(LikeAccumulationVO accumulation);
 }

--- a/src/main/java/com/nuguna/freview/admin/mapper/NoshowAccumulationMapper.java
+++ b/src/main/java/com/nuguna/freview/admin/mapper/NoshowAccumulationMapper.java
@@ -1,0 +1,10 @@
+package com.nuguna.freview.admin.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface NoshowAccumulationMapper {
+
+  int insertNoshowAccumulation(Long userSeq);
+  int updateNoshowAccumulation(Long userSeq);
+}

--- a/src/main/java/com/nuguna/freview/admin/service/ExperienceLogService.java
+++ b/src/main/java/com/nuguna/freview/admin/service/ExperienceLogService.java
@@ -1,0 +1,54 @@
+package com.nuguna.freview.admin.service;
+
+import com.nuguna.freview.admin.dto.ExperienceLogDTO;
+import com.nuguna.freview.admin.mapper.ExperienceMapper;
+import com.nuguna.freview.admin.mapper.ExperiencePostProcessingLogMapper;
+import com.nuguna.freview.admin.mapper.NoshowAccumulationMapper;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+public class ExperienceLogService {
+
+  private final ExperienceMapper experienceMapper;
+  private final NoshowAccumulationMapper noshowAccumulationMapper;
+  private final ExperiencePostProcessingLogMapper experiencePostProcessingLogMapper;
+
+  @Autowired
+  public ExperienceLogService(ExperienceMapper experienceMapper, NoshowAccumulationMapper noshowAccumulationMapper,
+      ExperiencePostProcessingLogMapper experiencePostProcessingLogMapper) {
+    this.experienceMapper = experienceMapper;
+    this.noshowAccumulationMapper = noshowAccumulationMapper;
+    this.experiencePostProcessingLogMapper = experiencePostProcessingLogMapper;
+  }
+
+  @Scheduled(fixedRate = 1000)
+  @Transactional
+  public void processExperiences() {
+
+    Long lastProcessedSeq = experiencePostProcessingLogMapper.getLastProcessedSeq();
+    if (lastProcessedSeq == null) {
+      lastProcessedSeq = 0L;
+    }
+
+    List<ExperienceLogDTO> experiences = experienceMapper.selectExperiencesToNoShow(lastProcessedSeq);
+
+    if (!experiences.isEmpty()) {
+      experiences.forEach(experience -> {
+        Long userSeqForAccumulation = (experience.getFromPostSeq() == null) ? experience.getToUserSeq() : experience.getFromUserSeq();
+        int rowUpdated = noshowAccumulationMapper.updateNoshowAccumulation(userSeqForAccumulation);
+        if (rowUpdated == 0) {
+          noshowAccumulationMapper.insertNoshowAccumulation(userSeqForAccumulation);
+        }
+      });
+
+      Long maxSeq = experiences.stream().mapToLong(ExperienceLogDTO::getSeq).max().getAsLong();
+      experiencePostProcessingLogMapper.updateLastProcessedSeq(maxSeq);
+    }
+  }
+}

--- a/src/main/java/com/nuguna/freview/admin/service/LikeLogService.java
+++ b/src/main/java/com/nuguna/freview/admin/service/LikeLogService.java
@@ -22,7 +22,6 @@ public class LikeLogService {
   private final LikeAccumulationMapper likeAccumulationMapper;
   private final LikePostProcessingLogMapper likePostProcessingLogMapper;
 
-
   @Autowired
   public LikeLogService(LikeLogMapper likeMapper, LikeAccumulationMapper likeAccumulationMapper,
       LikePostProcessingLogMapper likePostProcessingLogMapper) {
@@ -34,7 +33,6 @@ public class LikeLogService {
   @Scheduled(fixedRate = 1000)
   @Transactional
   public void processLikeLogs() {
-
     Long lastProcessedSeq = likePostProcessingLogMapper.getLastProcessedSeq();
     if (lastProcessedSeq == null) {
       lastProcessedSeq = 0L;
@@ -48,7 +46,7 @@ public class LikeLogService {
               Collectors.summingLong(log -> log.getCode().equals("LIKE") ? 1L : -1L)));
 
       likeCounts.forEach((postSeq, count) -> {
-        LikeAccumulationVO currentAccumulation = likeAccumulationMapper.findByPostSeq(postSeq);
+        LikeAccumulationVO currentAccumulation = likeAccumulationMapper.getByPostSeq(postSeq);
         if (currentAccumulation == null) {
           currentAccumulation = new LikeAccumulationVO(postSeq, count);
           likeAccumulationMapper.insert(currentAccumulation);

--- a/src/main/java/com/nuguna/freview/admin/service/impl/AdminServiceImpl.java
+++ b/src/main/java/com/nuguna/freview/admin/service/impl/AdminServiceImpl.java
@@ -26,7 +26,7 @@ public class AdminServiceImpl implements AdminService {
 
   @Override
   public List<CustomerInfoDTO> getCustomerList(Long previousUserSeq, String searchWord, Integer pageSize) {
-    if (searchWord == null) {
+    if (searchWord == null || searchWord.isEmpty()) {
       return adminMapper.selectCustomerList(previousUserSeq, pageSize);
     } else {
       return adminMapper.searchCustomer(previousUserSeq, searchWord, pageSize);

--- a/src/main/resources/mappers/admin/admin-map.xml
+++ b/src/main/resources/mappers/admin/admin-map.xml
@@ -26,6 +26,7 @@
     <result property="nickname" column="nickname"/>
     <result property="email" column="email"/>
     <result property="createdAt" column="created_at"/>
+    <result property="totalNoshow" column="total_no_show"/>
   </resultMap>
 
   <!-- storeManageMap 설정 -->
@@ -50,27 +51,30 @@
   <!-- 체험단 목록 조회 -->
   <select id="selectCustomerList" parameterType="map" resultMap="customerManageMap">
     SELECT
-      seq, code, nickname, email, created_at
-    FROM user
-    WHERE code = 'CUSTOMER'
-      AND seq &lt; #{previousUserSeq}
-      AND is_withdrawn = 0
-    ORDER BY seq DESC
+      u.seq, u.code, u.nickname, u.email, u.created_at, COALESCE(na.total_no_show, 0) AS total_no_show
+    FROM user u
+           LEFT JOIN noshow_accumulation na ON u.seq = na.user_seq
+    WHERE u.code = 'CUSTOMER'
+      AND u.seq &lt; #{previousUserSeq}
+      AND u.is_withdrawn = 0
+    ORDER BY u.seq DESC
       LIMIT #{limit}
   </select>
 
   <!-- 검색 조건에 부합하는 체험단 목록 조회 -->
   <select id="searchCustomer" parameterType="map" resultMap="customerManageMap">
     SELECT
-      seq, code, nickname, email, created_at
-    FROM user
-    WHERE code = 'CUSTOMER'
-      AND seq &lt; #{previousUserSeq}
-      AND (email LIKE CONCAT('%', #{searchWord}, '%') OR nickname LIKE CONCAT('%', #{searchWord}, '%'))
-      AND is_withdrawn = 0
-    ORDER BY seq DESC
+      u.seq, u.code, u.nickname, u.email, u.created_at, COALESCE(na.total_no_show, 0) AS total_no_show
+    FROM user u
+        LEFT JOIN noshow_accumulation na ON u.seq = na.user_seq
+    WHERE u.code = 'CUSTOMER'
+      AND u.seq &lt; #{previousUserSeq}
+      AND (u.email LIKE CONCAT('%', #{searchWord}, '%') OR u.nickname LIKE CONCAT('%', #{searchWord}, '%'))
+      AND u.is_withdrawn = 0
+    ORDER BY u.seq DESC
       LIMIT #{limit}
   </select>
+
   <!-- 스토어 목록 조회 -->
   <select id="selectStoreList" parameterType="map" resultMap="customerManageMap">
     SELECT

--- a/src/main/resources/mappers/admin/experience-map.xml
+++ b/src/main/resources/mappers/admin/experience-map.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.nuguna.freview.admin.mapper.ExperienceMapper">
+
+  <!-- resultMap -->
+  <!-- Experience resultMap -->
+  <resultMap id="experienceResultMap" type="com.nuguna.freview.admin.dto.ExperienceLogDTO">
+    <id property="seq" column="seq"/>
+    <result property="fromUserSeq" column="from_user_seq"/>
+    <result property="toUserSeq" column="to_user_seq"/>
+    <result property="fromPostSeq" column="from_post_seq"/>
+    <result property="status" column="status"/>
+  </resultMap>
+
+  <!-- 'NOSHOW'인 experience 데이터 조회 -->
+  <select id="selectExperiencesToNoShow" parameterType="long" resultMap="experienceResultMap">
+    SELECT seq, from_user_seq, to_user_seq, from_post_seq, status
+    FROM experience
+    WHERE status = 'NOSHOW' AND seq > #{lastProcessedSeq}
+    ORDER BY seq ASC
+    LIMIT 100
+  </select>
+
+</mapper>

--- a/src/main/resources/mappers/admin/experience-postprocessing-log-map.xml
+++ b/src/main/resources/mappers/admin/experience-postprocessing-log-map.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.nuguna.freview.admin.mapper.ExperiencePostProcessingLogMapper">
+
+  <!-- 마지막으로 처리한 seq 로깅 -->
+  <insert id="updateLastProcessedSeq" parameterType="long">
+    insert into experience_postprocessing_log (last_processed_seq, purpose)
+    values (#{seq}, 'NOSHOW_ACCUMULATION')
+  </insert>
+
+  <!-- 최근 처리된 작업 번호 가져오기 -->
+  <select id="getLastProcessedSeq" resultType="long">
+    SELECT last_processed_seq
+    FROM experience_postprocessing_log
+    WHERE purpose = 'NOSHOW_ACCUMULATION'
+    order by seq DESC
+    limit 1
+  </select>
+
+</mapper>

--- a/src/main/resources/mappers/admin/like-accumulation-map.xml
+++ b/src/main/resources/mappers/admin/like-accumulation-map.xml
@@ -12,14 +12,16 @@
   </resultMap>
 
   <!-- SQL 쿼리문 -->
-  <select id="findByPostSeq" parameterType="long" resultMap="likeAccumulationMap">
+  <select id="getByPostSeq" parameterType="long" resultMap="likeAccumulationMap">
     SELECT post_seq, total_like FROM like_accumulation
     WHERE post_seq = #{postSeq}
   </select>
+
   <insert id="insert">
     INSERT INTO like_accumulation (post_seq, total_like)
     VALUES (#{postSeq}, #{totalLike})
   </insert>
+
   <update id="update">
     UPDATE like_accumulation
     SET total_like = #{totalLike}

--- a/src/main/resources/mappers/admin/like-postprocessing-log-map.xml
+++ b/src/main/resources/mappers/admin/like-postprocessing-log-map.xml
@@ -4,6 +4,7 @@
 
 <mapper namespace="com.nuguna.freview.admin.mapper.LikePostProcessingLogMapper">
 
+  <!-- Sql 쿼리문 -->
   <insert id="updateLastProcessedSeq">
     INSERT INTO like_postprocessing_log (last_processed_like_seq)
     VALUES (#{seq})

--- a/src/main/resources/mappers/admin/noshow-accumulation-map.xml
+++ b/src/main/resources/mappers/admin/noshow-accumulation-map.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.nuguna.freview.admin.mapper.NoshowAccumulationMapper">
+
+  <!-- noshow_accumulation 데이터 삽입 또는 업데이트 -->
+  <insert id="insertNoshowAccumulation" parameterType="long">
+    INSERT INTO noshow_accumulation (user_seq, total_no_show)
+    VALUES (#{userSeq}, 1)
+  </insert>
+
+  <update id="updateNoshowAccumulation" parameterType="long">
+    UPDATE noshow_accumulation
+    SET total_no_show = total_no_show + 1
+    WHERE user_seq = #{userSeq}
+  </update>
+
+</mapper>

--- a/src/main/webapp/admin-management-customer.jsp
+++ b/src/main/webapp/admin-management-customer.jsp
@@ -63,6 +63,11 @@
     background: none;
     cursor: pointer;
   }
+
+  .high-noshow {
+    color: red !important;
+  }
+
 </style>
 
 <body>
@@ -169,7 +174,7 @@
                 <th>닉네임</th>
                 <th>아이디</th>
                 <th>가입일자</th>
-                <th>노쇼횟수</th>
+                <th>누적 노쇼 횟수</th>
                 <th>탈퇴</th>
               </tr>
               </thead>
@@ -270,12 +275,13 @@
       let htmlStr = "";
       $.map(data, function (user) {
         let formattedCreatedAt = dayjs(user["createdAt"]).format('YYYY-MM-DD HH:mm');
+        let highlightClass = user["totalNoshow"] > 3 ? 'high-noshow' : '';
 
         htmlStr += "<tr>";
         htmlStr += "<td>" + user["nickname"] + "</td>";
         htmlStr += "<td><a href='/brand-page?user_seq=" + user["seq"] + "'>" + user["email"] + "</a></td>";
         htmlStr += "<td>" + formattedCreatedAt + "</td>";
-        htmlStr += "<td>" + user["totalNoshow"] + "</td>";
+        htmlStr += "<td class='" + highlightClass + "'>" + user["totalNoshow"] + "</td>"; // 여기에 클래스 적용
         htmlStr += "<td><button class='btn btn-danger btn-sm delete-btn' data-bs-toggle='modal' data-bs-target='#deleteModal' data-id='" + user["email"] + "' data-seq='" + user["seq"] + "'>X</button></td>";
         htmlStr += "</tr>";
       });

--- a/src/main/webapp/admin-management-customer.jsp
+++ b/src/main/webapp/admin-management-customer.jsp
@@ -275,7 +275,7 @@
         htmlStr += "<td>" + user["nickname"] + "</td>";
         htmlStr += "<td><a href='/brand-page?user_seq=" + user["seq"] + "'>" + user["email"] + "</a></td>";
         htmlStr += "<td>" + formattedCreatedAt + "</td>";
-        htmlStr += "<td>" + "0" + "</td>";
+        htmlStr += "<td>" + user["totalNoshow"] + "</td>";
         htmlStr += "<td><button class='btn btn-danger btn-sm delete-btn' data-bs-toggle='modal' data-bs-target='#deleteModal' data-id='" + user["email"] + "' data-seq='" + user["seq"] + "'>X</button></td>";
         htmlStr += "</tr>";
       });


### PR DESCRIPTION
### [목적]
- 체험 관련 기록을 관리하는 experience 테이블에서 데이터를 추출하여 체험단 별 노쇼 횟수 누계 테이블을 운용할 수 있음
- 관리자의 체험단 관리 페이지에서 유저 별 누적 노쇼 횟수를 확인할 수 있음

### [로직]
- 스케줄러를 통해 experience 테이블의 기록을 accumulation 테이블에 합산하여 적용

<img width="1775" alt="image" src="https://github.com/user-attachments/assets/03d3d747-c5fa-4bf8-905b-cb898c143b9c">
- 누적 노쇼 횟수가 3회를 초과했을 경우 빨간 글씨로 노출하였음