### PR TITLE
[feat-customer] 체험단 브랜딩 수정 페이지 - 리뷰 로그 기능 구현 완료

### DIFF
--- a/src/main/java/com/nuguna/freview/customer/constant/CustomerConstant.java
+++ b/src/main/java/com/nuguna/freview/customer/constant/CustomerConstant.java
@@ -3,4 +3,6 @@ package com.nuguna.freview.customer.constant;
 public class CustomerConstant {
 
   public static final int CUSTOMER_MY_BRAND_REVIEW_LOG_SIZE = 5;
+  public static final int CUSTOMER_REVIEW_LOG_FIRST_PAGE_NUMBER = 1;
+  public static final int CUSTOMER_REVIEW_LOG_PAGE_BLOCK_SIZE = 5;
 }

--- a/src/main/java/com/nuguna/freview/customer/controller/CustomerReviewApiController.java
+++ b/src/main/java/com/nuguna/freview/customer/controller/CustomerReviewApiController.java
@@ -2,10 +2,9 @@ package com.nuguna.freview.customer.controller;
 
 import com.nuguna.freview.customer.dto.request.CustomerMyReviewsRetrieveRequestDTO;
 import com.nuguna.freview.customer.dto.request.CustomerReviewRegisterRequestDTO;
+import com.nuguna.freview.customer.dto.response.CustomerMyReviewsRetrieveResponseDTO;
 import com.nuguna.freview.customer.dto.response.CustomerReviewRegisterResponseDTO;
-import com.nuguna.freview.customer.dto.response.ReviewLogInfoDTO;
-import com.nuguna.freview.customer.service.CustomerReviewService;
-import java.util.List;
+import com.nuguna.freview.customer.service.ReviewService;
 import javax.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,28 +20,27 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/customer/review")
 public class CustomerReviewApiController {
 
-  private final CustomerReviewService customerReviewService;
+  private final ReviewService reviewService;
 
   @Autowired
-  public CustomerReviewApiController(CustomerReviewService customerReviewService) {
-    this.customerReviewService = customerReviewService;
+  public CustomerReviewApiController(ReviewService reviewService) {
+    this.reviewService = reviewService;
   }
 
   @RequestMapping(value = "/review", method = RequestMethod.POST)
   public ResponseEntity<CustomerReviewRegisterResponseDTO> registerCustomerReview(
       @Valid @RequestBody CustomerReviewRegisterRequestDTO customerReviewRegisterRequestDTO
   ) {
-    CustomerReviewRegisterResponseDTO responseDTO = customerReviewService.registerCustomerReview(
+    CustomerReviewRegisterResponseDTO responseDTO = reviewService.registerCustomerReview(
         customerReviewRegisterRequestDTO);
     return new ResponseEntity<>(responseDTO, HttpStatus.CREATED);
   }
 
   @RequestMapping(value = "/reviews", method = RequestMethod.GET)
-  public ResponseEntity<List<ReviewLogInfoDTO>> registerCustomerReview(
+  public ResponseEntity<CustomerMyReviewsRetrieveResponseDTO> registerCustomerReview(
       @Valid @RequestBody CustomerMyReviewsRetrieveRequestDTO customerMyReviewsRetrieveRequestDTO
   ) {
-    // reviewStatus 까지 함께 담는 DTO를 만들어야 함.
-    List<ReviewLogInfoDTO> responseDTO = customerReviewService.getReviews(
+    CustomerMyReviewsRetrieveResponseDTO responseDTO = reviewService.getCustomerMyReviews(
         customerMyReviewsRetrieveRequestDTO);
     return new ResponseEntity<>(responseDTO, HttpStatus.CREATED);
   }

--- a/src/main/java/com/nuguna/freview/customer/controller/CustomerReviewApiController.java
+++ b/src/main/java/com/nuguna/freview/customer/controller/CustomerReviewApiController.java
@@ -41,6 +41,7 @@ public class CustomerReviewApiController {
   public ResponseEntity<List<ReviewLogInfoDTO>> registerCustomerReview(
       @Valid @RequestBody CustomerMyReviewsRetrieveRequestDTO customerMyReviewsRetrieveRequestDTO
   ) {
+    // reviewStatus 까지 함께 담는 DTO를 만들어야 함.
     List<ReviewLogInfoDTO> responseDTO = customerReviewService.getReviews(
         customerMyReviewsRetrieveRequestDTO);
     return new ResponseEntity<>(responseDTO, HttpStatus.CREATED);

--- a/src/main/java/com/nuguna/freview/customer/controller/CustomerReviewApiController.java
+++ b/src/main/java/com/nuguna/freview/customer/controller/CustomerReviewApiController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RestController
-@RequestMapping("/api/customer/review")
+@RequestMapping("/api/customer")
 public class CustomerReviewApiController {
 
   private final ReviewService reviewService;

--- a/src/main/java/com/nuguna/freview/customer/controller/CustomerReviewApiController.java
+++ b/src/main/java/com/nuguna/freview/customer/controller/CustomerReviewApiController.java
@@ -31,6 +31,7 @@ public class CustomerReviewApiController {
   public ResponseEntity<CustomerReviewRegisterResponseDTO> registerCustomerReview(
       @Valid @RequestBody CustomerReviewRegisterRequestDTO customerReviewRegisterRequestDTO
   ) {
+    log.info("registerCustomerReview 들어옴");
     CustomerReviewRegisterResponseDTO responseDTO = reviewService.registerCustomerReview(
         customerReviewRegisterRequestDTO);
     return new ResponseEntity<>(responseDTO, HttpStatus.CREATED);

--- a/src/main/java/com/nuguna/freview/customer/controller/CustomerReviewApiController.java
+++ b/src/main/java/com/nuguna/freview/customer/controller/CustomerReviewApiController.java
@@ -37,13 +37,14 @@ public class CustomerReviewApiController {
     return new ResponseEntity<>(responseDTO, HttpStatus.CREATED);
   }
 
-  @RequestMapping(value = "/reviews", method = RequestMethod.GET)
+  @RequestMapping(value = "/reviews", method = RequestMethod.POST)
   public ResponseEntity<CustomerMyReviewsRetrieveResponseDTO> registerCustomerReview(
       @Valid @RequestBody CustomerMyReviewsRetrieveRequestDTO customerMyReviewsRetrieveRequestDTO
   ) {
     CustomerMyReviewsRetrieveResponseDTO responseDTO = reviewService.getCustomerMyReviews(
         customerMyReviewsRetrieveRequestDTO);
-    return new ResponseEntity<>(responseDTO, HttpStatus.CREATED);
+    log.info("{}", responseDTO.getReviewPageInfo().toString());
+    return new ResponseEntity<>(responseDTO, HttpStatus.OK);
   }
 
 }

--- a/src/main/java/com/nuguna/freview/customer/controller/CustomerReviewApiController.java
+++ b/src/main/java/com/nuguna/freview/customer/controller/CustomerReviewApiController.java
@@ -43,7 +43,6 @@ public class CustomerReviewApiController {
   ) {
     CustomerMyReviewsRetrieveResponseDTO responseDTO = reviewService.getCustomerMyReviews(
         customerMyReviewsRetrieveRequestDTO);
-    log.info("{}", responseDTO.getReviewPageInfo().toString());
     return new ResponseEntity<>(responseDTO, HttpStatus.OK);
   }
 

--- a/src/main/java/com/nuguna/freview/customer/controller/page/CustomerPageController.java
+++ b/src/main/java/com/nuguna/freview/customer/controller/page/CustomerPageController.java
@@ -25,10 +25,13 @@ public class CustomerPageController {
     CustomerMyBrandPageInfoResponseDTO brandPageInfo = customerPageService.getBrandPageInfo(
         userSeq);
 
+    log.info("reviewPagination INFO = {}", brandPageInfo.getReviewPaginationInfo());
+
     log.info(brandPageInfo.getReviewInfos().toString());
     log.info(brandPageInfo.getBrandInfo().toString());
     model.addAttribute("brandInfo", brandPageInfo.getBrandInfo());
     model.addAttribute("reviewInfos", brandPageInfo.getReviewInfos());
+    model.addAttribute("reviewPageInfo", brandPageInfo.getReviewPaginationInfo());
     model.addAttribute("userSeq", userSeq);
     return "customer-my-brand-info";
   }

--- a/src/main/java/com/nuguna/freview/customer/controller/page/CustomerPageController.java
+++ b/src/main/java/com/nuguna/freview/customer/controller/page/CustomerPageController.java
@@ -24,11 +24,7 @@ public class CustomerPageController {
   public String customerMyBrandPage(@RequestParam Long userSeq, Model model) {
     CustomerMyBrandPageInfoResponseDTO brandPageInfo = customerPageService.getBrandPageInfo(
         userSeq);
-
     log.info("reviewPagination INFO = {}", brandPageInfo.getReviewPaginationInfo());
-
-    log.info(brandPageInfo.getReviewInfos().toString());
-    log.info(brandPageInfo.getBrandInfo().toString());
     model.addAttribute("brandInfo", brandPageInfo.getBrandInfo());
     model.addAttribute("reviewInfos", brandPageInfo.getReviewInfos());
     model.addAttribute("reviewPageInfo", brandPageInfo.getReviewPaginationInfo());

--- a/src/main/java/com/nuguna/freview/customer/dto/request/CustomerMyReviewsRetrieveRequestDTO.java
+++ b/src/main/java/com/nuguna/freview/customer/dto/request/CustomerMyReviewsRetrieveRequestDTO.java
@@ -1,5 +1,7 @@
 package com.nuguna.freview.customer.dto.request;
 
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,8 +15,12 @@ public class CustomerMyReviewsRetrieveRequestDTO {
   // 추후 다른 유저가 해당 체험단의 리뷰를 보기 위한 ReviewsRetrieveRequestDTO를 통해서는
   // NOSHOW 상태의 리뷰를 조회할 수 없음.
 
+  @Min(1)
+  @NotNull
   private Long userSeq;
 
+  @Min(1)
+  @NotNull
   private Integer page;
 
 }

--- a/src/main/java/com/nuguna/freview/customer/dto/request/CustomerMyReviewsRetrieveRequestDTO.java
+++ b/src/main/java/com/nuguna/freview/customer/dto/request/CustomerMyReviewsRetrieveRequestDTO.java
@@ -15,6 +15,6 @@ public class CustomerMyReviewsRetrieveRequestDTO {
 
   private Long userSeq;
 
-  private Integer currentPage;
+  private Integer page;
 
 }

--- a/src/main/java/com/nuguna/freview/customer/dto/request/CustomerReviewRegisterRequestDTO.java
+++ b/src/main/java/com/nuguna/freview/customer/dto/request/CustomerReviewRegisterRequestDTO.java
@@ -1,5 +1,6 @@
 package com.nuguna.freview.customer.dto.request;
 
+import com.nuguna.freview.customer.validation.annotation.ValidUrl;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
@@ -19,6 +20,7 @@ public class CustomerReviewRegisterRequestDTO {
   @NotNull
   private Long reviewSeq;
 
+  @ValidUrl
   @NotBlank(message = "리뷰 URL은 비어있는 값이면 안됩니다.")
   private String reviewUrl;
 }

--- a/src/main/java/com/nuguna/freview/customer/dto/response/CustomerMyReviewsRetrieveResponseDTO.java
+++ b/src/main/java/com/nuguna/freview/customer/dto/response/CustomerMyReviewsRetrieveResponseDTO.java
@@ -1,0 +1,16 @@
+package com.nuguna.freview.customer.dto.response;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CustomerMyReviewsRetrieveResponseDTO {
+
+  private List<ReviewLogInfoDTO> reviewInfos;
+  private ReviewPaginationInfoResponseDTO reviewPaginationInfo;
+
+}

--- a/src/main/java/com/nuguna/freview/customer/dto/response/CustomerMyReviewsRetrieveResponseDTO.java
+++ b/src/main/java/com/nuguna/freview/customer/dto/response/CustomerMyReviewsRetrieveResponseDTO.java
@@ -11,6 +11,6 @@ import lombok.NoArgsConstructor;
 public class CustomerMyReviewsRetrieveResponseDTO {
 
   private List<ReviewLogInfoDTO> reviewInfos;
-  private ReviewPaginationInfoResponseDTO reviewPaginationInfo;
+  private ReviewPaginationInfoResponseDTO reviewPageInfo;
 
 }

--- a/src/main/java/com/nuguna/freview/customer/dto/response/ReviewLogInfoDTO.java
+++ b/src/main/java/com/nuguna/freview/customer/dto/response/ReviewLogInfoDTO.java
@@ -11,6 +11,7 @@ import lombok.NoArgsConstructor;
 public class ReviewLogInfoDTO {
 
   private Long seq;
+  private Long storeSeq;
   private String storeName;
   private String status;
   private String url;

--- a/src/main/java/com/nuguna/freview/customer/dto/response/ReviewPaginationInfoResponseDTO.java
+++ b/src/main/java/com/nuguna/freview/customer/dto/response/ReviewPaginationInfoResponseDTO.java
@@ -1,12 +1,12 @@
 package com.nuguna.freview.customer.dto.response;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Getter
+@ToString
 @NoArgsConstructor
-@AllArgsConstructor
 public class ReviewPaginationInfoResponseDTO {
 
   private Integer currentPage;
@@ -14,5 +14,13 @@ public class ReviewPaginationInfoResponseDTO {
   private Integer endPage;
   private Boolean hasNext;
   private Boolean hasPrevious;
+
+  public ReviewPaginationInfoResponseDTO(Integer currentPage, Integer startPage, Integer endPage) {
+    this.currentPage = currentPage;
+    this.startPage = startPage;
+    this.endPage = endPage;
+    this.hasNext = currentPage < endPage;
+    this.hasPrevious = currentPage > startPage;
+  }
 
 }

--- a/src/main/java/com/nuguna/freview/customer/dto/response/ReviewPaginationInfoResponseDTO.java
+++ b/src/main/java/com/nuguna/freview/customer/dto/response/ReviewPaginationInfoResponseDTO.java
@@ -1,11 +1,13 @@
 package com.nuguna.freview.customer.dto.response;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @Getter
 @ToString
+@AllArgsConstructor
 @NoArgsConstructor
 public class ReviewPaginationInfoResponseDTO {
 
@@ -14,13 +16,5 @@ public class ReviewPaginationInfoResponseDTO {
   private Integer endPage;
   private Boolean hasNext;
   private Boolean hasPrevious;
-
-  public ReviewPaginationInfoResponseDTO(Integer currentPage, Integer startPage, Integer endPage) {
-    this.currentPage = currentPage;
-    this.startPage = startPage;
-    this.endPage = endPage;
-    this.hasNext = currentPage < endPage;
-    this.hasPrevious = currentPage > startPage;
-  }
 
 }

--- a/src/main/java/com/nuguna/freview/customer/dto/response/ReviewPaginationInfoResponseDTO.java
+++ b/src/main/java/com/nuguna/freview/customer/dto/response/ReviewPaginationInfoResponseDTO.java
@@ -1,0 +1,18 @@
+package com.nuguna.freview.customer.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReviewPaginationInfoResponseDTO {
+
+  private Integer currentPage;
+  private Integer startPage;
+  private Integer endPage;
+  private Boolean hasNext;
+  private Boolean hasPrevious;
+
+}

--- a/src/main/java/com/nuguna/freview/customer/dto/response/page/CustomerMyBrandPageInfoResponseDTO.java
+++ b/src/main/java/com/nuguna/freview/customer/dto/response/page/CustomerMyBrandPageInfoResponseDTO.java
@@ -1,6 +1,7 @@
 package com.nuguna.freview.customer.dto.response.page;
 
 import com.nuguna.freview.customer.dto.response.ReviewLogInfoDTO;
+import com.nuguna.freview.customer.dto.response.ReviewPaginationInfoResponseDTO;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -13,4 +14,5 @@ public class CustomerMyBrandPageInfoResponseDTO {
 
   private CustomerBrandInfoResponseDTO brandInfo;
   private List<ReviewLogInfoDTO> reviewInfos;
+  private ReviewPaginationInfoResponseDTO reviewPaginationInfo;
 }

--- a/src/main/java/com/nuguna/freview/customer/exception/AlreadyExistReviewException.java
+++ b/src/main/java/com/nuguna/freview/customer/exception/AlreadyExistReviewException.java
@@ -1,0 +1,12 @@
+package com.nuguna.freview.customer.exception;
+
+public class AlreadyExistReviewException extends RuntimeException {
+
+  public AlreadyExistReviewException() {
+    super();
+  }
+
+  public AlreadyExistReviewException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/com/nuguna/freview/customer/exception/IllegalReviewPageAccessException.java
+++ b/src/main/java/com/nuguna/freview/customer/exception/IllegalReviewPageAccessException.java
@@ -1,0 +1,13 @@
+package com.nuguna.freview.customer.exception;
+
+public class IllegalReviewPageAccessException extends RuntimeException {
+
+  public IllegalReviewPageAccessException() {
+    super();
+  }
+
+  public IllegalReviewPageAccessException(String message) {
+    super(message);
+  }
+
+}

--- a/src/main/java/com/nuguna/freview/customer/exception/MalformedReviewUrlException.java
+++ b/src/main/java/com/nuguna/freview/customer/exception/MalformedReviewUrlException.java
@@ -1,0 +1,12 @@
+package com.nuguna.freview.customer.exception;
+
+public class MalformedReviewUrlException extends RuntimeException {
+
+  public MalformedReviewUrlException() {
+    super();
+  }
+
+  public MalformedReviewUrlException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/com/nuguna/freview/customer/exception/handler/CustomerApiExceptionHandler.java
+++ b/src/main/java/com/nuguna/freview/customer/exception/handler/CustomerApiExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.nuguna.freview.customer.exception.handler;
 
 import com.nuguna.freview.customer.exception.AlreadyExistNicknameException;
+import com.nuguna.freview.customer.exception.AlreadyExistReviewException;
 import com.nuguna.freview.customer.exception.IllegalReviewException;
 import com.nuguna.freview.customer.exception.IllegalReviewPageAccessException;
 import com.nuguna.freview.customer.exception.MalformedReviewUrlException;
@@ -23,6 +24,11 @@ public class CustomerApiExceptionHandler {
   @ExceptionHandler(IllegalReviewException.class)
   public ResponseEntity<ErrorResponse> handleReviewException(IllegalReviewException ex) {
     return new ResponseEntity<>(new ErrorResponse(ex.getMessage(), null), HttpStatus.NOT_FOUND);
+  }
+
+  @ExceptionHandler(AlreadyExistReviewException.class)
+  public ResponseEntity<ErrorResponse> handleExistReviewException(AlreadyExistReviewException ex) {
+    return new ResponseEntity<>(new ErrorResponse(ex.getMessage(), null), HttpStatus.BAD_REQUEST);
   }
 
   @ExceptionHandler(MalformedReviewUrlException.class)

--- a/src/main/java/com/nuguna/freview/customer/exception/handler/CustomerApiExceptionHandler.java
+++ b/src/main/java/com/nuguna/freview/customer/exception/handler/CustomerApiExceptionHandler.java
@@ -2,6 +2,7 @@ package com.nuguna.freview.customer.exception.handler;
 
 import com.nuguna.freview.customer.exception.AlreadyExistNicknameException;
 import com.nuguna.freview.customer.exception.IllegalReviewException;
+import com.nuguna.freview.customer.exception.IllegalReviewPageAccessException;
 import com.nuguna.freview.global.exception.ErrorResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -20,6 +21,12 @@ public class CustomerApiExceptionHandler {
 
   @ExceptionHandler(IllegalReviewException.class)
   public ResponseEntity<ErrorResponse> handleReviewException(IllegalReviewException ex) {
+    return new ResponseEntity<>(new ErrorResponse(ex.getMessage(), null), HttpStatus.NOT_FOUND);
+  }
+
+  @ExceptionHandler(IllegalReviewPageAccessException.class)
+  public ResponseEntity<ErrorResponse> handleReviewPageAcessException(
+      IllegalReviewPageAccessException ex) {
     return new ResponseEntity<>(new ErrorResponse(ex.getMessage(), null), HttpStatus.NOT_FOUND);
   }
 

--- a/src/main/java/com/nuguna/freview/customer/exception/handler/CustomerApiExceptionHandler.java
+++ b/src/main/java/com/nuguna/freview/customer/exception/handler/CustomerApiExceptionHandler.java
@@ -3,6 +3,7 @@ package com.nuguna.freview.customer.exception.handler;
 import com.nuguna.freview.customer.exception.AlreadyExistNicknameException;
 import com.nuguna.freview.customer.exception.IllegalReviewException;
 import com.nuguna.freview.customer.exception.IllegalReviewPageAccessException;
+import com.nuguna.freview.customer.exception.MalformedReviewUrlException;
 import com.nuguna.freview.global.exception.ErrorResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -22,6 +23,12 @@ public class CustomerApiExceptionHandler {
   @ExceptionHandler(IllegalReviewException.class)
   public ResponseEntity<ErrorResponse> handleReviewException(IllegalReviewException ex) {
     return new ResponseEntity<>(new ErrorResponse(ex.getMessage(), null), HttpStatus.NOT_FOUND);
+  }
+
+  @ExceptionHandler(MalformedReviewUrlException.class)
+  public ResponseEntity<ErrorResponse> handleMalformedUrlReviewException(
+      MalformedReviewUrlException ex) {
+    return new ResponseEntity<>(new ErrorResponse(ex.getMessage(), null), HttpStatus.BAD_REQUEST);
   }
 
   @ExceptionHandler(IllegalReviewPageAccessException.class)

--- a/src/main/java/com/nuguna/freview/customer/mapper/CustomerReviewMapper.java
+++ b/src/main/java/com/nuguna/freview/customer/mapper/CustomerReviewMapper.java
@@ -6,6 +6,8 @@ import org.apache.ibatis.annotations.Param;
 
 public interface CustomerReviewMapper {
 
+  Boolean checkAlreadyExistReview(@Param("reviewSeq") Long reviewSeq);
+
   Boolean checkIsValidReview(@Param("userSeq") Long userSeq, @Param("reviewSeq") Long reviewSeq);
 
   void registerReview(@Param("reviewSeq") Long reviewSeq, @Param("reviewUrl") String reviewUrl);

--- a/src/main/java/com/nuguna/freview/customer/mapper/CustomerReviewMapper.java
+++ b/src/main/java/com/nuguna/freview/customer/mapper/CustomerReviewMapper.java
@@ -13,4 +13,5 @@ public interface CustomerReviewMapper {
   List<ReviewLogInfoDTO> getReviewsInfo(@Param("userSeq") Long userSeq,
       @Param("offset") int offset, @Param("pageSize") int pageSize);
 
+  Integer getReviewCount(@Param("userSeq") Long userSeq);
 }

--- a/src/main/java/com/nuguna/freview/customer/service/ReviewService.java
+++ b/src/main/java/com/nuguna/freview/customer/service/ReviewService.java
@@ -2,15 +2,14 @@ package com.nuguna.freview.customer.service;
 
 import com.nuguna.freview.customer.dto.request.CustomerMyReviewsRetrieveRequestDTO;
 import com.nuguna.freview.customer.dto.request.CustomerReviewRegisterRequestDTO;
+import com.nuguna.freview.customer.dto.response.CustomerMyReviewsRetrieveResponseDTO;
 import com.nuguna.freview.customer.dto.response.CustomerReviewRegisterResponseDTO;
-import com.nuguna.freview.customer.dto.response.ReviewLogInfoDTO;
-import java.util.List;
 
-public interface CustomerReviewService {
+public interface ReviewService {
 
   CustomerReviewRegisterResponseDTO registerCustomerReview(
       CustomerReviewRegisterRequestDTO customerReviewRegisterRequestDTO);
 
-  List<ReviewLogInfoDTO> getReviews(
+  CustomerMyReviewsRetrieveResponseDTO getCustomerMyReviews(
       CustomerMyReviewsRetrieveRequestDTO customerMyReviewsRetrieveRequestDTO);
 }

--- a/src/main/java/com/nuguna/freview/customer/service/impl/CustomerPageServiceImpl.java
+++ b/src/main/java/com/nuguna/freview/customer/service/impl/CustomerPageServiceImpl.java
@@ -1,8 +1,11 @@
 package com.nuguna.freview.customer.service.impl;
 
 import static com.nuguna.freview.customer.constant.CustomerConstant.CUSTOMER_MY_BRAND_REVIEW_LOG_SIZE;
+import static com.nuguna.freview.customer.constant.CustomerConstant.CUSTOMER_REVIEW_LOG_FIRST_PAGE_NUMBER;
+import static com.nuguna.freview.customer.constant.CustomerConstant.CUSTOMER_REVIEW_LOG_PAGE_BLOCK_SIZE;
 
 import com.nuguna.freview.customer.dto.response.ReviewLogInfoDTO;
+import com.nuguna.freview.customer.dto.response.ReviewPaginationInfoResponseDTO;
 import com.nuguna.freview.customer.dto.response.page.CustomerBrandInfoResponseDTO;
 import com.nuguna.freview.customer.dto.response.page.CustomerMyBrandPageInfoResponseDTO;
 import com.nuguna.freview.customer.mapper.CustomerPageMapper;
@@ -12,6 +15,7 @@ import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
@@ -28,10 +32,24 @@ public class CustomerPageServiceImpl implements CustomerPageService {
   }
 
   @Override
+  @Transactional(readOnly = true)
   public CustomerMyBrandPageInfoResponseDTO getBrandPageInfo(Long userSeq) {
     CustomerBrandInfoResponseDTO brandInfo = customerPageMapper.getBrandInfo(userSeq);
     List<ReviewLogInfoDTO> reviewsInfo = customerReviewMapper.getReviewsInfo(userSeq, 0,
         CUSTOMER_MY_BRAND_REVIEW_LOG_SIZE);
-    return new CustomerMyBrandPageInfoResponseDTO(brandInfo, reviewsInfo);
+    int reviewCount = customerReviewMapper.getReviewCount(userSeq);
+
+    int endPage = (reviewCount / 5) + 1;
+    if (reviewCount > CUSTOMER_MY_BRAND_REVIEW_LOG_SIZE
+        * (CUSTOMER_REVIEW_LOG_PAGE_BLOCK_SIZE - 1)) {
+      endPage = CUSTOMER_REVIEW_LOG_PAGE_BLOCK_SIZE;
+    }
+
+    ReviewPaginationInfoResponseDTO reviewPaginationInfo
+        = new ReviewPaginationInfoResponseDTO(CUSTOMER_REVIEW_LOG_FIRST_PAGE_NUMBER,
+        CUSTOMER_REVIEW_LOG_FIRST_PAGE_NUMBER, endPage);
+    return new CustomerMyBrandPageInfoResponseDTO(brandInfo, reviewsInfo, reviewPaginationInfo);
   }
+
+
 }

--- a/src/main/java/com/nuguna/freview/customer/service/impl/CustomerPageServiceImpl.java
+++ b/src/main/java/com/nuguna/freview/customer/service/impl/CustomerPageServiceImpl.java
@@ -39,15 +39,23 @@ public class CustomerPageServiceImpl implements CustomerPageService {
         CUSTOMER_MY_BRAND_REVIEW_LOG_SIZE);
     int reviewCount = customerReviewMapper.getReviewCount(userSeq);
 
-    int endPage = (reviewCount / 5) + 1;
+    int endPage;
+    if (reviewCount % CUSTOMER_MY_BRAND_REVIEW_LOG_SIZE == 0) {
+      endPage = reviewCount / CUSTOMER_MY_BRAND_REVIEW_LOG_SIZE;
+    } else {
+      endPage = (reviewCount / CUSTOMER_MY_BRAND_REVIEW_LOG_SIZE) + 1;
+    }
+
     if (reviewCount > CUSTOMER_MY_BRAND_REVIEW_LOG_SIZE
         * (CUSTOMER_REVIEW_LOG_PAGE_BLOCK_SIZE - 1)) {
       endPage = CUSTOMER_REVIEW_LOG_PAGE_BLOCK_SIZE;
     }
 
+    boolean hasNext = (endPage > 1);
+
     ReviewPaginationInfoResponseDTO reviewPaginationInfo
         = new ReviewPaginationInfoResponseDTO(CUSTOMER_REVIEW_LOG_FIRST_PAGE_NUMBER,
-        CUSTOMER_REVIEW_LOG_FIRST_PAGE_NUMBER, endPage);
+        CUSTOMER_REVIEW_LOG_FIRST_PAGE_NUMBER, endPage, hasNext, false);
     return new CustomerMyBrandPageInfoResponseDTO(brandInfo, reviewsInfo, reviewPaginationInfo);
   }
 

--- a/src/main/java/com/nuguna/freview/customer/service/impl/CustomerReviewServiceImpl.java
+++ b/src/main/java/com/nuguna/freview/customer/service/impl/CustomerReviewServiceImpl.java
@@ -43,9 +43,9 @@ public class CustomerReviewServiceImpl implements CustomerReviewService {
   public List<ReviewLogInfoDTO> getReviews(
       CustomerMyReviewsRetrieveRequestDTO customerMyReviewsRetrieveRequestDTO) {
     Long userSeq = customerMyReviewsRetrieveRequestDTO.getUserSeq();
-    Integer currentPage = customerMyReviewsRetrieveRequestDTO.getCurrentPage();
+    Integer page = customerMyReviewsRetrieveRequestDTO.getPage();
 
     return customerReviewMapper.getReviewsInfo(userSeq,
-        (currentPage - 1) * CUSTOMER_MY_BRAND_REVIEW_LOG_SIZE, CUSTOMER_MY_BRAND_REVIEW_LOG_SIZE);
+        (page - 1) * CUSTOMER_MY_BRAND_REVIEW_LOG_SIZE, CUSTOMER_MY_BRAND_REVIEW_LOG_SIZE);
   }
 }

--- a/src/main/java/com/nuguna/freview/customer/service/impl/ReviewServiceImpl.java
+++ b/src/main/java/com/nuguna/freview/customer/service/impl/ReviewServiceImpl.java
@@ -9,6 +9,7 @@ import com.nuguna.freview.customer.dto.response.CustomerMyReviewsRetrieveRespons
 import com.nuguna.freview.customer.dto.response.CustomerReviewRegisterResponseDTO;
 import com.nuguna.freview.customer.dto.response.ReviewLogInfoDTO;
 import com.nuguna.freview.customer.dto.response.ReviewPaginationInfoResponseDTO;
+import com.nuguna.freview.customer.exception.AlreadyExistReviewException;
 import com.nuguna.freview.customer.exception.IllegalReviewException;
 import com.nuguna.freview.customer.exception.IllegalReviewPageAccessException;
 import com.nuguna.freview.customer.mapper.CustomerReviewMapper;
@@ -39,6 +40,11 @@ public class ReviewServiceImpl implements ReviewService {
     if (!customerReviewMapper.checkIsValidReview(userSeq, reviewSeq)) {
       throw new IllegalReviewException("존재하지 않는 리뷰입니다.");
     }
+
+    if (customerReviewMapper.checkAlreadyExistReview(reviewSeq)) {
+      throw new AlreadyExistReviewException("이미 등록완료 처리된 리뷰입니다.");
+    }
+
     customerReviewMapper.registerReview(reviewSeq, reviewUrl);
     return new CustomerReviewRegisterResponseDTO(reviewUrl);
   }

--- a/src/main/java/com/nuguna/freview/customer/validation/UrlValidator.java
+++ b/src/main/java/com/nuguna/freview/customer/validation/UrlValidator.java
@@ -1,0 +1,24 @@
+package com.nuguna.freview.customer.validation;
+
+import com.nuguna.freview.customer.validation.annotation.ValidUrl;
+import java.net.MalformedURLException;
+import java.net.URL;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class UrlValidator implements ConstraintValidator<ValidUrl, String> {
+
+  @Override
+  public boolean isValid(String urlField, ConstraintValidatorContext context) {
+    if (urlField == null || urlField.isEmpty()) {
+      return false;
+    }
+
+    try {
+      new URL(urlField);
+      return true;
+    } catch (MalformedURLException e) {
+      return false;
+    }
+  }
+}

--- a/src/main/java/com/nuguna/freview/customer/validation/annotation/ValidUrl.java
+++ b/src/main/java/com/nuguna/freview/customer/validation/annotation/ValidUrl.java
@@ -1,0 +1,21 @@
+package com.nuguna.freview.customer.validation.annotation;
+
+import com.nuguna.freview.customer.validation.UrlValidator;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+@Constraint(validatedBy = UrlValidator.class)
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidUrl {
+
+  String message() default "유효한 URL 형식이 아닙니다.";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/resources/mappers/customer/customer-review-map.xml
+++ b/src/main/resources/mappers/customer/customer-review-map.xml
@@ -44,4 +44,11 @@
     ORDER BY r.created_at ASC
     LIMIT #{offset}, #{pageSize}
   </select>
+
+  <select id="getReviewCount" resultType="java.lang.Integer">
+    select count(*)
+    from review
+    where customer_seq = #{userSeq}
+  </select>
+
 </mapper>

--- a/src/main/resources/mappers/customer/customer-review-map.xml
+++ b/src/main/resources/mappers/customer/customer-review-map.xml
@@ -13,6 +13,13 @@
     <result property="createdAt" column="created_at"/>
   </resultMap>
 
+  <select id="checkAlreadyExistReview" resultType="Boolean">
+    select count(1) > 0
+    from review
+    where seq = #{reviewSeq}
+      and status = 'WRITTEN'
+  </select>
+
 
   <select id="checkIsValidReview" resultType="Boolean">
     select count(1) > 0

--- a/src/main/resources/mappers/customer/customer-review-map.xml
+++ b/src/main/resources/mappers/customer/customer-review-map.xml
@@ -5,6 +5,7 @@
 <mapper namespace="com.nuguna.freview.customer.mapper.CustomerReviewMapper">
   <resultMap id="reviewLogInfoMap" type="com.nuguna.freview.customer.dto.response.ReviewLogInfoDTO">
     <id property="seq" column="seq"/>
+    <result property="storeSeq" column="store_seq"/>
     <result property="storeName" column="store_name"/>
     <result property="status" column="status"/>
     <result property="url" column="url"/>
@@ -30,6 +31,7 @@
   <select id="getReviewsInfo"
     resultMap="reviewLogInfoMap">
     SELECT r.seq,
+           r.store_seq,
            nsbi.store_name,
            r.status,
            r.url,

--- a/src/main/webapp/customer-my-brand-info.jsp
+++ b/src/main/webapp/customer-my-brand-info.jsp
@@ -987,7 +987,12 @@
                                       $('#reviewModal').modal('hide');
                                     },
                                     error: function (err) {
-                                      alert('리뷰 등록에 실패했습니다. 다시 시도해주세요.');
+                                      console.log(err);
+                                      if (err.responseJSON && err.responseJSON.message) {
+                                        alert(err.responseJSON.message);
+                                      } else {
+                                        alert('리뷰 등록에 실패했습니다. 다시 시도해주세요.');
+                                      }
                                     }
                                   });
                                 });

--- a/src/main/webapp/customer-my-brand-info.jsp
+++ b/src/main/webapp/customer-my-brand-info.jsp
@@ -847,17 +847,74 @@
                                              style="font-size: medium; color: indianred;">
                                             노쇼 상태인 리뷰는 노출되지 않습니다.
                                         </div>
-                                        <div class="pagination-container">
-                                            <button id="prev-block-button"
-                                                    class="btn btn-primary edit-btn" disabled>&lt;
-                                            </button>
+                                        <%--<div class="pagination-container">
+                                            <c:if test="${reviewPageInfo.hasPrevious}">
+                                                <button id="prev-block-button"
+                                                        class="btn btn-primary edit-btn">&lt;
+                                                </button>
+                                            </c:if>
                                             <div id="page-buttons"
                                                  class="d-flex justify-content-center mx-2">
-                                                <!-- 페이지 번호 버튼들이 여기에 추가됩니다 -->
+                                                <c:forEach var="page"
+                                                           begin="${reviewPageInfo.startPage}"
+                                                           end="${reviewPageInfo.endPage}">
+                                                    <c:choose>
+                                                        <c:when test="${page == reviewPageInfo.currentPage}">
+                                                            <button class="btn btn-secondary edit-btn"
+                                                                    disabled>${page}</button>
+                                                        </c:when>
+                                                        <c:otherwise>
+                                                            <button class="btn btn-primary edit-btn"
+                                                                    onclick="loadPage(${page})">${page}</button>
+                                                        </c:otherwise>
+                                                    </c:choose>
+                                                </c:forEach>
+                                            </div>
+                                            <c:if test="${reviewPageInfo.hasNext}">
+                                                <button id="next-block-button"
+                                                        class="btn btn-primary edit-btn">&gt;
+                                                </button>
+                                            </c:if>
+                                        </div>--%>
+                                        <div class="pagination-container">
+                                            <%--<c:if test="${reviewPageInfo.hasPrevious}">
+                                                <button id="prev-block-button"
+                                                        class="btn btn-primary edit-btn">&lt;
+                                                </button>
+                                            </c:if>--%>
+                                            <button id="prev-block-button"
+                                                    class="btn btn-primary edit-btn"
+                                                    style="${reviewPageInfo.hasPrevious ? '' : 'display:none;'}">
+                                                &lt;
+                                            </button>
+
+                                            <div id="page-buttons"
+                                                 class="d-flex justify-content-center mx-2">
+                                                <c:forEach var="page"
+                                                           begin="${reviewPageInfo.startPage}"
+                                                           end="${reviewPageInfo.endPage}">
+                                                    <c:choose>
+                                                        <c:when test="${page == reviewPageInfo.currentPage}">
+                                                            <button class="btn btn-secondary edit-btn"
+                                                                    disabled>${page}</button>
+                                                        </c:when>
+                                                        <c:otherwise>
+                                                            <button class="btn btn-primary edit-btn"
+                                                                    data-page="${page}">${page}</button>
+                                                        </c:otherwise>
+                                                    </c:choose>
+                                                </c:forEach>
                                             </div>
                                             <button id="next-block-button"
-                                                    class="btn btn-primary edit-btn" disabled>&gt;
+                                                    class="btn btn-primary edit-btn"
+                                                    style="${reviewPageInfo.hasNext ? '' : 'display:none;'}">
+                                                &gt;
                                             </button>
+                                            <%--<c:if test="${reviewPageInfo.hasNext}">
+                                                <button id="next-block-button"
+                                                        class="btn btn-primary edit-btn">&gt;
+                                                </button>
+                                            </c:if>--%>
                                         </div>
                                     </div>
                                 </div>
@@ -907,7 +964,7 @@
                                 });
 
                                 $('#reviewForm').on('submit', function (event) {
-                                  // event.preventDefault();
+                                  event.preventDefault();
                                   var formData = {
                                     userSeq: $('#userSeq').val(),
                                     reviewSeq: $('#reviewSeq').val(),
@@ -935,112 +992,110 @@
                                   });
                                 });
                               });
-                            </script>
-                            <%--<script>
-                              $(document).ready(function () {
-                                var currentPage = ${reviewPageInfo.currentPage};
-                                var startPage = ${reviewPageInfo.startPage};
-                                var endPage = ${reviewPageInfo.endPage};
-                                var hasNext = ${reviewPageInfo.hasNext};
-                                var hasPrevious = ${reviewPageInfo.hasPrevious};
 
-                                function fetchReviewLogs(page) {
-                                  $.ajax({
-                                    url: '/api/customer/reviews',
-                                    method: 'GET',
-                                    data: {page: page},
-                                    success: function (response) {
-                                      var reviewLogs = response.logs;
-                                      var hasPrevious = response.hasPrevious;
-                                      var hasNext = response.hasNext;
-                                      totalPages = response.totalPages;
+                              function initializePagination(reviewPageInfo) {
 
-                                      renderReviewLogs(reviewLogs);
-                                      renderPageButtons();
-                                      updatePaginationButtons(hasPrevious, hasNext);
-                                    },
-                                    error: function (err) {
-                                      alert('리뷰 로그 데이터를 가져오는데 실패하였습니다.');
-                                      renderPageButtons();
-                                    }
+                                $('#prev-block-button').off('click').on('click', function () {
+                                  if (reviewPageInfo.hasPrevious) {
+                                    loadPage(reviewPageInfo.currentPage - 1);
+                                  }
+                                });
+
+                                $('#next-block-button').off('click').on('click', function () {
+                                  if (reviewPageInfo.hasNext) {
+                                    loadPage(reviewPageInfo.currentPage + 1);
+                                  }
+                                });
+
+                                $('#page-buttons').empty();
+                                for (var i = reviewPageInfo.startPage; i <= reviewPageInfo.endPage;
+                                    i++) {
+                                  var pageButton = $(
+                                      '<button class="btn btn-primary edit-btn" data-page="' + i
+                                      + '">' + i + '</button>');
+                                  if (i === reviewPageInfo.currentPage) {
+                                    pageButton.addClass('btn-secondary').prop('disabled', true);
+                                  }
+                                  pageButton.on('click', function () {
+                                    var pageNumber = $(this).data('page');
+                                    loadPage(pageNumber);
                                   });
+                                  $('#page-buttons').append(pageButton);
                                 }
 
-                                function renderReviewLogs(reviewLogs) {
-                                  var tbody = $('#review-log-table tbody');
-                                  tbody.empty(); // 기존 데이터를 제거합니다.
-
-                                  reviewLogs.forEach(function (log) {
-                                    var row = $('<tr>');
-                                    row.append($('<td>').text(log.storeName));
-                                    row.append($('<td>').text(log.visitDate));
-                                    row.append($('<td>').text(log.reviewWritten));
-                                    tbody.append(row);
-                                  });
+                                if (reviewPageInfo.hasPrevious) {
+                                  $('#prev-block-button').show();
+                                } else {
+                                  $('#prev-block-button').hide();
                                 }
 
-                                function renderPageButtons() {
-                                  var pageButtonsDiv = $('#page-buttons');
-                                  pageButtonsDiv.empty(); // 기존 페이지 버튼을 제거합니다.
+                                if (reviewPageInfo.hasNext) {
+                                  $('#next-block-button').show();
+                                } else {
+                                  $('#next-block-button').hide();
+                                }
+                              }
 
-                                  var currentBlock = Math.floor(
-                                      (currentPage - 1) / pagesPerBlock);
-                                  var startPage = currentBlock * pagesPerBlock + 1;
-                                  var endPage = Math.min(startPage + pagesPerBlock - 1,
-                                      totalPages);
+                              function loadPage(page) {
+                                var userSeq = $('#userSeq').val();
 
-                                  for (var i = startPage; i <= endPage; i++) {
-                                    var pageButton = $('<button>')
-                                    .text(i)
-                                    .addClass(
-                                        'btn btn-outline-primary mx-1 datatable-pagination-list-item-link')
-                                    .attr('data-page', i)
-                                    .attr('aria-label', 'Page ' + i);
-                                    if (i === currentPage) {
-                                      pageButton.addClass('active');
-                                    }
-                                    pageButton.on('click', function () {
-                                      var page = parseInt($(this).attr('data-page'));
-                                      currentPage = page;
-                                      fetchReviewLogs(currentPage);
+                                $.ajax({
+                                  url: '/api/customer/reviews',
+                                  method: 'POST',
+                                  contentType: 'application/json',
+                                  data: JSON.stringify({'userSeq': userSeq, 'page': page}),
+                                  success: function (response) {
+                                    // 리뷰 목록 업데이트
+                                    var reviewInfos = response.reviewInfos;
+                                    var reviewLogTableBody = $('#review-log-table tbody');
+                                    reviewLogTableBody.empty();
+                                    $.each(reviewInfos, function (index, review) {
+                                      var visitDate = review.visitDate;
+                                      if (review.status === 'NOSHOW') {
+                                        visitDate = '노쇼';
+                                      }
+                                      var reviewRow = '<tr>' +
+                                          '<td><a href="/brand/' + review.storeSeq + '">'
+                                          + review.storeName + '</a></td>' +
+                                          '<td>' + visitDate + '</td>' +
+                                          '<td>' + renderReviewButton(review) + '</td>' +
+                                          '</tr>';
+                                      reviewLogTableBody.append(reviewRow);
                                     });
-                                    pageButtonsDiv.append(pageButton);
+                                    initializePagination(response.reviewPageInfo);
+                                  },
+                                  error: function (err) {
+                                    alert('페이지를 로드하는데 실패했습니다. 다시 시도해주세요.');
                                   }
+                                })
+                                ;
+                              }
+
+                              function renderReviewButton(review) {
+                                if (review.status === 'WRITTEN' || review.status
+                                    === 'STORE_HIDDEN') {
+                                  return '<a href="' + review.url
+                                      + '" class="btn btn-success btn-sm">리뷰 확인</a>';
+                                } else if (review.status === 'UNWRITTEN') {
+                                  return '<button class="btn btn-sm" style="background-color: indianred; border-color: indianred; color: white;" data-toggle="modal" data-target="#reviewModal" data-review-seq="'
+                                      + review.seq + '">리뷰 등록하기</button>';
+                                } else if (review.status === 'NOSHOW') {
+                                  return '<button class="btn btn-secondary btn-sm" disabled>노쇼</button>';
                                 }
+                                return '';
+                              }
 
-                                function updatePaginationButtons(hasPrevious, hasNext) {
-                                  var currentBlock = Math.floor(
-                                      (currentPage - 1) / pagesPerBlock);
-                                  var totalBlocks = Math.ceil(totalPages / pagesPerBlock);
-
-                                  $('#prev-block-button').prop('disabled', currentBlock === 0);
-                                  $('#next-block-button').prop('disabled',
-                                      currentBlock >= totalBlocks - 1);
-                                }
-
-                                $('#prev-block-button').click(function () {
-                                  var currentBlock = Math.floor(
-                                      (currentPage - 1) / pagesPerBlock);
-                                  if (currentBlock > 0) {
-                                    currentPage = (currentBlock - 1) * pagesPerBlock + 1;
-                                    fetchReviewLogs(currentPage);
-                                  }
-                                });
-
-                                $('#next-block-button').click(function () {
-                                  var currentBlock = Math.floor(
-                                      (currentPage - 1) / pagesPerBlock);
-                                  var totalBlocks = Math.ceil(totalPages / pagesPerBlock);
-                                  if (currentBlock < totalBlocks - 1) {
-                                    currentPage = (currentBlock + 1) * pagesPerBlock + 1;
-                                    fetchReviewLogs(currentPage);
-                                  }
-                                });
-
-                                // 초기 데이터 로드
-                                fetchReviewLogs(currentPage);
-                              });
-                            </script>--%>
+                              var reviewPageInfo = {
+                                currentPage: ${reviewPageInfo.currentPage},
+                                startPage: ${reviewPageInfo.startPage},
+                                endPage: ${reviewPageInfo.endPage},
+                                hasPrevious: ${reviewPageInfo.hasPrevious},
+                                hasNext: ${reviewPageInfo.hasNext}
+                              };
+                              // 초기 페이지 로드 시 페이지네이션 초기화
+                              <%--var initialPageInfo = ${reviewPageInfo}; // 서버에서 전달받은 초기 페이지 정보--%>
+                              initializePagination(reviewPageInfo);
+                            </script>
 
 </main>
 

--- a/src/main/webapp/customer-my-brand-info.jsp
+++ b/src/main/webapp/customer-my-brand-info.jsp
@@ -864,10 +864,6 @@
                                             </c:forEach>
                                             </tbody>
                                         </table>
-                                        <%--<div class="alert alert-custom alert-custom-bottom"
-                                             role="alert">
-                                            노쇼한 리뷰는 제 3자에게 노출되지 않습니다.
-                                        </div>--%>
                                         <div class="pagination-container">
                                             <button id="prev-block-button"
                                                     class="btn btn-primary edit-btn" disabled>&lt;
@@ -883,63 +879,6 @@
                                     </div>
                                 </div>
                             </div>
-                            <%--<div class="row">
-                                <div class="col-lg-3 col-md-4 label">리뷰 로그</div>
-                                <div class="col-lg-8 col-md-6">
-                                    <div class="alert alert-custom" role="alert">
-                                        노쇼한 리뷰는 제 3자에게 노출되지 않습니다.
-                                    </div>
-                                    <table class="table table-striped table-bordered text-center"
-                                           id="review-log-table">
-                                        <thead>
-                                        <tr>
-                                            <th>스토어명</th>
-                                            <th>방문일자</th>
-                                            <th>리뷰 작성여부</th>
-                                        </tr>
-                                        </thead>
-                                        <tbody>
-                                        <c:forEach var="review" items="${reviewInfos}">
-                                            <c:set var="visitDate" value="${review.visitDate}"/>
-                                            <c:if test="${review.status == 'NOSHOW'}">
-                                                <c:set var="visitDate" value="노쇼"/>
-                                            </c:if>
-                                            <tr>
-                                                <td>
-                                                    <a href="/brand/${review.storeName}">${review.storeName}</a>
-                                                </td>
-                                                <td>${visitDate}</td>
-                                                <td>
-                                                    <c:choose>
-                                                        <c:when test="${review.status == 'WRITTEN' || review.status == 'STORE_HIDDEN'}">
-                                                            <a href="${review.url}">O</a>
-                                                        </c:when>
-                                                        <c:when test="${review.status == 'UNWRITTEN'}">
-                                                            X
-                                                        </c:when>
-                                                        <c:when test="${review.status == 'NOSHOW'}">
-                                                            노쇼
-                                                        </c:when>
-                                                    </c:choose>
-                                                </td>
-                                            </tr>
-                                        </c:forEach>
-                                        </tbody>
-                                    </table>
-                                    <div class="pagination-container">
-                                        <button id="prev-block-button"
-                                                class="btn btn-primary edit-btn" disabled>&lt;
-                                        </button>
-                                        <div id="page-buttons"
-                                             class="d-flex justify-content-center mx-2">
-                                            <!-- 페이지 번호 버튼들이 여기에 추가됩니다 -->
-                                        </div>
-                                        <button id="next-block-button"
-                                                class="btn btn-primary edit-btn" disabled>&gt;
-                                        </button>
-                                    </div>
-                                </div>
-                            </div>--%>
 
                             <%-- <script>
                                $(document).ready(function () {

--- a/src/main/webapp/customer-my-brand-info.jsp
+++ b/src/main/webapp/customer-my-brand-info.jsp
@@ -42,6 +42,13 @@
       .d-flex.justify-content-center {
         gap: 0.5rem;
       }
+
+      .btn-secondary {
+        background-color: rgb(128, 128, 128);
+        border-color: rgb(128, 128, 128);
+        color: white;
+      }
+
     </style>
 
     <link rel="stylesheet"
@@ -783,6 +790,7 @@
                                 });
                               });
                             </script>
+
                             <div class="row">
                                 <div class="col-lg-3 col-md-4 label">리뷰 로그</div>
                                 <div class="col-lg-8 col-md-6">
@@ -793,7 +801,7 @@
                                             <tr>
                                                 <th>스토어명</th>
                                                 <th>방문일자</th>
-                                                <th>리뷰 작성여부</th>
+                                                <th>리뷰</th>
                                             </tr>
                                             </thead>
                                             <tbody>
@@ -810,13 +818,22 @@
                                                     <td>
                                                         <c:choose>
                                                             <c:when test="${review.status == 'WRITTEN' || review.status == 'STORE_HIDDEN'}">
-                                                                <a href="${review.url}">O</a>
+                                                                <a href="${review.url}"
+                                                                   class="btn btn-success btn-sm">리뷰
+                                                                    확인</a>
                                                             </c:when>
                                                             <c:when test="${review.status == 'UNWRITTEN'}">
-                                                                X
+                                                                <button class="btn btn-pink btn-sm"
+                                                                        data-toggle="modal"
+                                                                        data-target="#reviewModal"
+                                                                        data-review-seq="${review.seq}">
+                                                                    리뷰 등록하기
+                                                                </button>
                                                             </c:when>
                                                             <c:when test="${review.status == 'NOSHOW'}">
-                                                                노쇼
+                                                                <button class="btn btn-secondary btn-sm"
+                                                                        disabled>노쇼
+                                                                </button>
                                                             </c:when>
                                                         </c:choose>
                                                     </td>
@@ -840,6 +857,76 @@
                                 </div>
                             </div>
 
+                            <!-- 리뷰 등록 모달 -->
+                            <div class="modal fade" id="reviewModal" tabindex="-1" role="dialog"
+                                 aria-labelledby="reviewModalLabel" aria-hidden="true">
+                                <div class="modal-dialog" role="document">
+                                    <div class="modal-content">
+                                        <div class="modal-header">
+                                            <h5 class="modal-title" id="reviewModalLabel">리뷰 등록</h5>
+                                            <button type="button" class="close" data-dismiss="modal"
+                                                    aria-label="Close">
+                                                <span aria-hidden="true">&times;</span>
+                                            </button>
+                                        </div>
+                                        <div class="modal-body">
+                                            <form id="reviewForm">
+                                                <div class="form-group">
+                                                    <label for="reviewUrl">리뷰 URL</label>
+                                                    <input type="url" class="form-control"
+                                                           id="reviewUrl" name="reviewUrl" required>
+                                                </div>
+                                                <input type="hidden" id="reviewSeq"
+                                                       name="reviewSeq">
+                                                <input type="hidden" id="userSeq" name="userSeq"
+                                                       value="${userSeq}">
+                                                <button type="submit" class="btn btn-primary">등록
+                                                </button>
+                                            </form>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+
+
+                            <script>
+                              $(document).ready(function () {
+                                $('#reviewModal').on('show.bs.modal', function (event) {
+                                  var button = $(event.relatedTarget);
+                                  var reviewSeq = button.data('review-seq');
+                                  var modal = $(this);
+                                  modal.find('#reviewSeq').val(reviewSeq);
+                                });
+
+                                $('#reviewForm').on('submit', function (event) {
+                                  event.preventDefault();
+                                  var formData = {
+                                    userSeq: $('#userSeq').val(),
+                                    reviewSeq: $('#reviewSeq').val(),
+                                    reviewUrl: $('#reviewUrl').val()
+                                  };
+
+                                  $.ajax({
+                                    url: '/api/customer/review',
+                                    method: 'POST',
+                                    contentType: 'application/json',
+                                    data: JSON.stringify(formData),
+                                    success: function (response) {
+                                      $('#reviewModal').modal('hide');
+                                      var reviewSeq = formData.reviewSeq;
+                                      var reviewUrl = response.reviewUrl;
+                                      var reviewButton = $(
+                                          'button[data-review-seq="' + reviewSeq + '"]');
+                                      reviewButton.replaceWith('<a href="' + reviewUrl
+                                          + '" class="btn btn-success btn-sm">리뷰 확인</a>');
+                                    },
+                                    error: function (xhr, status, error) {
+                                      alert('리뷰 등록에 실패했습니다. 다시 시도해주세요.');
+                                    }
+                                  });
+                                });
+                              });
+                            </script>
                             <%--<script>
                               $(document).ready(function () {
                                 var currentPage = ${reviewPageInfo.currentPage};
@@ -948,11 +1035,11 @@
 
 </main>
 
-
 <footer id="footer" class="footer">
     <div class="copyright">
         &copy; Copyright <strong><span><a
-            href="https://github.com/nugunaTeam/FReview2"> nugunaTeam </a></span></strong>. All
+            href="https://github.com/nugunaTeam/FReview2"> nugunaTeam </a></span></strong>.
+        All
         Rights
         Reserved
     </div>
@@ -961,12 +1048,14 @@
     </div>
 </footer><!-- End Footer -->
 
-<a href="#" class="back-to-top d-flex align-items-center justify-content-center"><i
+<a href="#"
+   class="back-to-top d-flex align-items-center justify-content-center"><i
         class="bi bi-arrow-up-short"></i></a>
 <!-- jquery  -->
 
 <!-- icon bootstrap -->
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
+<script
+        src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
         integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
         crossorigin="anonymous"></script>
 

--- a/src/main/webapp/customer-my-brand-info.jsp
+++ b/src/main/webapp/customer-my-brand-info.jsp
@@ -51,8 +51,8 @@
 
     </style>
 
-    <link rel="stylesheet"
-          href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css">
+    <%-- <link rel="stylesheet"
+           href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css">--%>
     <style>
       .alert-custom {
         background-color: transparent;
@@ -135,10 +135,10 @@
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
 
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+    <%--<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
           rel="stylesheet"
           integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
-          crossorigin="anonymous">
+          crossorigin="anonymous">--%>
 
     <link rel="stylesheet"
           href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
@@ -847,47 +847,12 @@
                                              style="font-size: medium; color: indianred;">
                                             노쇼 상태인 리뷰는 노출되지 않습니다.
                                         </div>
-                                        <%--<div class="pagination-container">
-                                            <c:if test="${reviewPageInfo.hasPrevious}">
-                                                <button id="prev-block-button"
-                                                        class="btn btn-primary edit-btn">&lt;
-                                                </button>
-                                            </c:if>
-                                            <div id="page-buttons"
-                                                 class="d-flex justify-content-center mx-2">
-                                                <c:forEach var="page"
-                                                           begin="${reviewPageInfo.startPage}"
-                                                           end="${reviewPageInfo.endPage}">
-                                                    <c:choose>
-                                                        <c:when test="${page == reviewPageInfo.currentPage}">
-                                                            <button class="btn btn-secondary edit-btn"
-                                                                    disabled>${page}</button>
-                                                        </c:when>
-                                                        <c:otherwise>
-                                                            <button class="btn btn-primary edit-btn"
-                                                                    onclick="loadPage(${page})">${page}</button>
-                                                        </c:otherwise>
-                                                    </c:choose>
-                                                </c:forEach>
-                                            </div>
-                                            <c:if test="${reviewPageInfo.hasNext}">
-                                                <button id="next-block-button"
-                                                        class="btn btn-primary edit-btn">&gt;
-                                                </button>
-                                            </c:if>
-                                        </div>--%>
                                         <div class="pagination-container">
-                                            <%--<c:if test="${reviewPageInfo.hasPrevious}">
-                                                <button id="prev-block-button"
-                                                        class="btn btn-primary edit-btn">&lt;
-                                                </button>
-                                            </c:if>--%>
                                             <button id="prev-block-button"
                                                     class="btn btn-primary edit-btn"
                                                     style="${reviewPageInfo.hasPrevious ? '' : 'display:none;'}">
                                                 &lt;
                                             </button>
-
                                             <div id="page-buttons"
                                                  class="d-flex justify-content-center mx-2">
                                                 <c:forEach var="page"
@@ -910,11 +875,6 @@
                                                     style="${reviewPageInfo.hasNext ? '' : 'display:none;'}">
                                                 &gt;
                                             </button>
-                                            <%--<c:if test="${reviewPageInfo.hasNext}">
-                                                <button id="next-block-button"
-                                                        class="btn btn-primary edit-btn">&gt;
-                                                </button>
-                                            </c:if>--%>
                                         </div>
                                     </div>
                                 </div>
@@ -945,7 +905,8 @@
                                                        name="reviewSeq">
                                                 <input type="hidden" id="userSeq" name="userSeq"
                                                        value="${userSeq}">
-                                                <button type="submit" class="btn btn-primary">등록
+                                                <button id="reviewInsert" <%--type="submit"--%>
+                                                        class="btn btn-primary">등록
                                                 </button>
                                             </form>
                                         </div>
@@ -955,7 +916,10 @@
 
 
                             <script>
+                              currentReviewLogPage = 1;
+
                               $(document).ready(function () {
+
                                 $('#reviewModal').on('show.bs.modal', function (event) {
                                   var button = $(event.relatedTarget);
                                   var reviewSeq = button.data('review-seq');
@@ -977,14 +941,15 @@
                                     contentType: 'application/json',
                                     data: JSON.stringify(formData),
                                     success: function (response) {
+                                      console.log(response);
                                       var reviewSeq = formData.reviewSeq;
                                       var reviewUrl = response.reviewUrl;
                                       var reviewButton = $(
                                           'button[data-review-seq="' + reviewSeq + '"]');
                                       reviewButton.replaceWith('<a href="' + reviewUrl
                                           + '" class="btn btn-success btn-sm">리뷰 확인</a>');
-                                      alert('리뷰 등록이 완료되었습니다.');
                                       $('#reviewModal').modal('hide');
+                                      alert('리뷰 등록이 완료되었습니다.');
                                     },
                                     error: function (err) {
                                       console.log(err);
@@ -1067,6 +1032,7 @@
                                           '</tr>';
                                       reviewLogTableBody.append(reviewRow);
                                     });
+                                    currentReviewLogPage = page;
                                     initializePagination(response.reviewPageInfo);
                                   },
                                   error: function (err) {
@@ -1097,8 +1063,6 @@
                                 hasPrevious: ${reviewPageInfo.hasPrevious},
                                 hasNext: ${reviewPageInfo.hasNext}
                               };
-                              // 초기 페이지 로드 시 페이지네이션 초기화
-                              <%--var initialPageInfo = ${reviewPageInfo}; // 서버에서 전달받은 초기 페이지 정보--%>
                               initializePagination(reviewPageInfo);
                             </script>
 
@@ -1123,10 +1087,10 @@
 <!-- jquery  -->
 
 <!-- icon bootstrap -->
-<script
+<%--<script
         src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
         integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
-        crossorigin="anonymous"></script>
+        crossorigin="anonymous"></script>--%>
 
 <!-- Vendor JS Files -->
 <script src="/assets/vendor/apexcharts/apexcharts.min.js"></script>

--- a/src/main/webapp/customer-my-brand-info.jsp
+++ b/src/main/webapp/customer-my-brand-info.jsp
@@ -783,46 +783,6 @@
                                 });
                               });
                             </script>
-                            <%--<div class="row">
-                                <div class="col-lg-3 col-md-4 label">리뷰 로그</div>
-                                <div class="col-lg-8 col-md-6">
-                                    <table class="table table-striped table-bordered text-center"
-                                           id="review-log-table">
-                                        <thead>
-                                        <tr>
-                                            <th>스토어명</th>
-                                            <th>방문일자</th>
-                                            <th>리뷰 작성여부</th>
-                                        </tr>
-                                        </thead>
-                                        <tbody>
-                                        <tr>
-                                            <th scope="row">1</th>
-                                            <td>Brandon Jacob</td>
-                                            <td>Designer</td>
-                                        </tr>
-                                        <tr>
-                                            <th scope="row">2</th>
-                                            <td>Bridie Kessler</td>
-                                            <td>Developer</td>
-                                        </tr>
-                                        <tr>
-                                            <th scope="row">3</th>
-                                            <td>Ashleigh Langosh</td>
-                                            <td>Finance</td>
-                                        </tr>
-                                        <tr>
-                                            <th scope="row">4</th>
-                                            <td>Angus Grady</td>
-                                            <td>HR</td>
-                                        </tr>
-                                        <tr>
-                                            <th scope="row">5</th>
-                                            <td>Raheem Lehner</td>
-                                            <td>Dynamic Division Officer</td>
-                                        </tr>
-                                        </tbody>
-                                    </table>--%>
                             <div class="row">
                                 <div class="col-lg-3 col-md-4 label">리뷰 로그</div>
                                 <div class="col-lg-8 col-md-6">
@@ -844,7 +804,7 @@
                                                 </c:if>
                                                 <tr>
                                                     <td>
-                                                        <a href="/brand/${review.storeName}">${review.storeName}</a>
+                                                        <a href="/brand/${review.storeSeq}">${review.storeName}</a>
                                                     </td>
                                                     <td>${visitDate}</td>
                                                     <td>
@@ -880,118 +840,121 @@
                                 </div>
                             </div>
 
-                            <%-- <script>
-                               $(document).ready(function () {
-                                 var currentPage = 1;
-                                 var totalPages = 50; // 예시: 총 페이지 수는 50이라고 가정
-                                 var pagesPerBlock = 5;
+                            <%--<script>
+                              $(document).ready(function () {
+                                var currentPage = ${reviewPageInfo.currentPage};
+                                var startPage = ${reviewPageInfo.startPage};
+                                var endPage = ${reviewPageInfo.endPage};
+                                var hasNext = ${reviewPageInfo.hasNext};
+                                var hasPrevious = ${reviewPageInfo.hasPrevious};
 
-                                 function fetchReviewLogs(page) {
-                                   $.ajax({
-                                     url: '/api/review-logs',
-                                     method: 'GET',
-                                     data: {page: page},
-                                     success: function (response) {
-                                       var reviewLogs = response.logs;
-                                       var hasPrevious = response.hasPrevious;
-                                       var hasNext = response.hasNext;
-                                       totalPages = response.totalPages;
+                                function fetchReviewLogs(page) {
+                                  $.ajax({
+                                    url: '/api/customer/reviews',
+                                    method: 'GET',
+                                    data: {page: page},
+                                    success: function (response) {
+                                      var reviewLogs = response.logs;
+                                      var hasPrevious = response.hasPrevious;
+                                      var hasNext = response.hasNext;
+                                      totalPages = response.totalPages;
 
-                                       renderReviewLogs(reviewLogs);
-                                       renderPageButtons();
-                                       updatePaginationButtons(hasPrevious, hasNext);
-                                     },
-                                     error: function (err) {
-                                       alert('리뷰 로그 데이터를 가져오는데 실패하였습니다.');
-                                       renderPageButtons();
-                                     }
-                                   });
-                                 }
+                                      renderReviewLogs(reviewLogs);
+                                      renderPageButtons();
+                                      updatePaginationButtons(hasPrevious, hasNext);
+                                    },
+                                    error: function (err) {
+                                      alert('리뷰 로그 데이터를 가져오는데 실패하였습니다.');
+                                      renderPageButtons();
+                                    }
+                                  });
+                                }
 
-                                 function renderReviewLogs(reviewLogs) {
-                                   var tbody = $('#review-log-table tbody');
-                                   tbody.empty(); // 기존 데이터를 제거합니다.
+                                function renderReviewLogs(reviewLogs) {
+                                  var tbody = $('#review-log-table tbody');
+                                  tbody.empty(); // 기존 데이터를 제거합니다.
 
-                                   reviewLogs.forEach(function (log) {
-                                     var row = $('<tr>');
-                                     row.append($('<td>').text(log.storeName));
-                                     row.append($('<td>').text(log.visitDate));
-                                     row.append($('<td>').text(log.reviewWritten));
-                                     tbody.append(row);
-                                   });
-                                 }
+                                  reviewLogs.forEach(function (log) {
+                                    var row = $('<tr>');
+                                    row.append($('<td>').text(log.storeName));
+                                    row.append($('<td>').text(log.visitDate));
+                                    row.append($('<td>').text(log.reviewWritten));
+                                    tbody.append(row);
+                                  });
+                                }
 
-                                 function renderPageButtons() {
-                                   var pageButtonsDiv = $('#page-buttons');
-                                   pageButtonsDiv.empty(); // 기존 페이지 버튼을 제거합니다.
+                                function renderPageButtons() {
+                                  var pageButtonsDiv = $('#page-buttons');
+                                  pageButtonsDiv.empty(); // 기존 페이지 버튼을 제거합니다.
 
-                                   var currentBlock = Math.floor(
-                                       (currentPage - 1) / pagesPerBlock);
-                                   var startPage = currentBlock * pagesPerBlock + 1;
-                                   var endPage = Math.min(startPage + pagesPerBlock - 1,
-                                       totalPages);
+                                  var currentBlock = Math.floor(
+                                      (currentPage - 1) / pagesPerBlock);
+                                  var startPage = currentBlock * pagesPerBlock + 1;
+                                  var endPage = Math.min(startPage + pagesPerBlock - 1,
+                                      totalPages);
 
-                                   for (var i = startPage; i <= endPage; i++) {
-                                     var pageButton = $('<button>')
-                                     .text(i)
-                                     .addClass(
-                                         'btn btn-outline-primary mx-1 datatable-pagination-list-item-link')
-                                     .attr('data-page', i)
-                                     .attr('aria-label', 'Page ' + i);
-                                     if (i === currentPage) {
-                                       pageButton.addClass('active');
-                                     }
-                                     pageButton.on('click', function () {
-                                       var page = parseInt($(this).attr('data-page'));
-                                       currentPage = page;
-                                       fetchReviewLogs(currentPage);
-                                     });
-                                     pageButtonsDiv.append(pageButton);
-                                   }
-                                 }
+                                  for (var i = startPage; i <= endPage; i++) {
+                                    var pageButton = $('<button>')
+                                    .text(i)
+                                    .addClass(
+                                        'btn btn-outline-primary mx-1 datatable-pagination-list-item-link')
+                                    .attr('data-page', i)
+                                    .attr('aria-label', 'Page ' + i);
+                                    if (i === currentPage) {
+                                      pageButton.addClass('active');
+                                    }
+                                    pageButton.on('click', function () {
+                                      var page = parseInt($(this).attr('data-page'));
+                                      currentPage = page;
+                                      fetchReviewLogs(currentPage);
+                                    });
+                                    pageButtonsDiv.append(pageButton);
+                                  }
+                                }
 
-                                 function updatePaginationButtons(hasPrevious, hasNext) {
-                                   var currentBlock = Math.floor(
-                                       (currentPage - 1) / pagesPerBlock);
-                                   var totalBlocks = Math.ceil(totalPages / pagesPerBlock);
+                                function updatePaginationButtons(hasPrevious, hasNext) {
+                                  var currentBlock = Math.floor(
+                                      (currentPage - 1) / pagesPerBlock);
+                                  var totalBlocks = Math.ceil(totalPages / pagesPerBlock);
 
-                                   $('#prev-block-button').prop('disabled', currentBlock === 0);
-                                   $('#next-block-button').prop('disabled',
-                                       currentBlock >= totalBlocks - 1);
-                                 }
+                                  $('#prev-block-button').prop('disabled', currentBlock === 0);
+                                  $('#next-block-button').prop('disabled',
+                                      currentBlock >= totalBlocks - 1);
+                                }
 
-                                 $('#prev-block-button').click(function () {
-                                   var currentBlock = Math.floor(
-                                       (currentPage - 1) / pagesPerBlock);
-                                   if (currentBlock > 0) {
-                                     currentPage = (currentBlock - 1) * pagesPerBlock + 1;
-                                     fetchReviewLogs(currentPage);
-                                   }
-                                 });
+                                $('#prev-block-button').click(function () {
+                                  var currentBlock = Math.floor(
+                                      (currentPage - 1) / pagesPerBlock);
+                                  if (currentBlock > 0) {
+                                    currentPage = (currentBlock - 1) * pagesPerBlock + 1;
+                                    fetchReviewLogs(currentPage);
+                                  }
+                                });
 
-                                 $('#next-block-button').click(function () {
-                                   var currentBlock = Math.floor(
-                                       (currentPage - 1) / pagesPerBlock);
-                                   var totalBlocks = Math.ceil(totalPages / pagesPerBlock);
-                                   if (currentBlock < totalBlocks - 1) {
-                                     currentPage = (currentBlock + 1) * pagesPerBlock + 1;
-                                     fetchReviewLogs(currentPage);
-                                   }
-                                 });
+                                $('#next-block-button').click(function () {
+                                  var currentBlock = Math.floor(
+                                      (currentPage - 1) / pagesPerBlock);
+                                  var totalBlocks = Math.ceil(totalPages / pagesPerBlock);
+                                  if (currentBlock < totalBlocks - 1) {
+                                    currentPage = (currentBlock + 1) * pagesPerBlock + 1;
+                                    fetchReviewLogs(currentPage);
+                                  }
+                                });
 
-                                 // 초기 데이터 로드
-                                 fetchReviewLogs(currentPage);
-                               });
+                                // 초기 데이터 로드
+                                fetchReviewLogs(currentPage);
+                              });
+                            </script>--%>
 
-                             </script>--%>
+</main>
 
 
-</main><!-- End #main -->
-
-<!-- ======= Footer ======= -->
 <footer id="footer" class="footer">
     <div class="copyright">
-        &copy; Copyright <strong><span>nugunaTeam</span></strong>. All Rights Reserved
+        &copy; Copyright <strong><span><a
+            href="https://github.com/nugunaTeam/FReview2"> nugunaTeam </a></span></strong>. All
+        Rights
+        Reserved
     </div>
     <div class="credits">
         Designed by <a href="https://bootstrapmade.com/">BootstrapMade</a>

--- a/src/main/webapp/customer-my-brand-info.jsp
+++ b/src/main/webapp/customer-my-brand-info.jsp
@@ -132,7 +132,8 @@
     <link href="/assets/css/style.css" rel="stylesheet">
     <link href="/assets/css/style-h.css" rel="stylesheet">
 
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
 
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
           rel="stylesheet"
@@ -823,7 +824,8 @@
                                                                     확인</a>
                                                             </c:when>
                                                             <c:when test="${review.status == 'UNWRITTEN'}">
-                                                                <button class="btn btn-pink btn-sm"
+                                                                <button class="btn btn-sm"
+                                                                        style="background-color: indianred; border-color: indianred; color: white;"
                                                                         data-toggle="modal"
                                                                         data-target="#reviewModal"
                                                                         data-review-seq="${review.seq}">
@@ -841,6 +843,10 @@
                                             </c:forEach>
                                             </tbody>
                                         </table>
+                                        <div class="d-flex justify-content-end mt-1"
+                                             style="font-size: medium; color: indianred;">
+                                            노쇼 상태인 리뷰는 노출되지 않습니다.
+                                        </div>
                                         <div class="pagination-container">
                                             <button id="prev-block-button"
                                                     class="btn btn-primary edit-btn" disabled>&lt;
@@ -875,6 +881,8 @@
                                                     <label for="reviewUrl">리뷰 URL</label>
                                                     <input type="url" class="form-control"
                                                            id="reviewUrl" name="reviewUrl" required>
+                                                    <small style="color: indianred;">한번 등록한 리뷰의 URL은
+                                                        수정 불가능합니다.</small>
                                                 </div>
                                                 <input type="hidden" id="reviewSeq"
                                                        name="reviewSeq">
@@ -899,7 +907,7 @@
                                 });
 
                                 $('#reviewForm').on('submit', function (event) {
-                                  event.preventDefault();
+                                  // event.preventDefault();
                                   var formData = {
                                     userSeq: $('#userSeq').val(),
                                     reviewSeq: $('#reviewSeq').val(),
@@ -912,15 +920,16 @@
                                     contentType: 'application/json',
                                     data: JSON.stringify(formData),
                                     success: function (response) {
-                                      $('#reviewModal').modal('hide');
                                       var reviewSeq = formData.reviewSeq;
                                       var reviewUrl = response.reviewUrl;
                                       var reviewButton = $(
                                           'button[data-review-seq="' + reviewSeq + '"]');
                                       reviewButton.replaceWith('<a href="' + reviewUrl
                                           + '" class="btn btn-success btn-sm">리뷰 확인</a>');
+                                      alert('리뷰 등록이 완료되었습니다.');
+                                      $('#reviewModal').modal('hide');
                                     },
-                                    error: function (xhr, status, error) {
+                                    error: function (err) {
                                       alert('리뷰 등록에 실패했습니다. 다시 시도해주세요.');
                                     }
                                   });

--- a/src/main/webapp/customer-my-brand-info.jsp
+++ b/src/main/webapp/customer-my-brand-info.jsp
@@ -44,6 +44,35 @@
       }
     </style>
 
+    <link rel="stylesheet"
+          href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css">
+    <style>
+      .alert-custom {
+        background-color: transparent;
+        color: orange;
+        border: none;
+        text-align: right;
+        font-size: 1rem;
+      }
+
+      .pagination-container {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        margin-top: 20px;
+      }
+
+      .table-container {
+        position: relative;
+      }
+
+      .alert-custom-bottom {
+        position: absolute;
+        bottom: -30px;
+        right: 0;
+      }
+    </style>
+
     <style>
       .form-control {
         width: 100%;
@@ -643,121 +672,6 @@
                                 </div>
                             </div>
 
-                            <%--<script>
-                              $(document).ready(function () {
-                                $('#tag-select').select2({
-                                  width: '100%',
-                                  templateSelection: function (option) {
-                                    var color = $(option.element).data('custom-color');
-                                    return $('<span style="color: ' + color + '">' + option.text
-                                        + '</span>');
-                                  }
-                                });
-
-                                var selectedTags = ${brandInfo.tagInfos};
-
-                                function initializeTagSelect() {
-                                  var tagSelect = $('#tag-select');
-                                  tagSelect.val(selectedTags).trigger('change');
-                                  updateTagMessage();
-                                }
-
-                                function updateTagMessage() {
-                                  var selectedOptions = $('#tag-select').val();
-                                  var messageElement = $('#tag-select-message');
-
-                                  if (selectedOptions === null || selectedOptions.length === 0) {
-                                    messageElement.text('아직 선택한 태그가 없어요.');
-                                  } else {
-                                    messageElement.text('');
-                                  }
-                                }
-
-                                initializeTagSelect();
-
-                                $('#tag-select').on('select2:select',
-                                    function (e) {
-                                      var selectedOptions = $(this).val();
-                                      if (selectedOptions.length > 2) {
-                                        var $element = $(e.params.data.element);
-                                        $element.prop("selected", false);
-                                        $(this).trigger('change');
-                                        alert('태그는 2개까지만 선택할 수 있습니다');
-                                      } else {
-                                        updateTagMessage();
-                                      }
-                                    });
-
-                                $('#tag-select').on('change', function () {
-                                  $(this).find('option:selected').addClass('selected-option');
-                                  $(this).find('option:not(:selected)').removeClass(
-                                      'selected-option');
-                                  updateTagMessage();
-                                });
-
-                                $("#tag-update-btn").click(function () {
-                                  $(this).hide();
-                                  $("#tag-cancel-btn, #tag-submit-btn").show();
-                                  $('#tag-select').prop('disabled', false).select2({
-                                    width: '100%',
-                                    templateSelection: function (option) {
-                                      var color = $(option.element).data('custom-color');
-                                      return $('<span style="color: ' + color + '">' + option.text
-                                          + '</span>');
-                                    }
-                                  });
-                                });
-
-                                $('#tag-cancel-btn').click(function () {
-                                  $(this).hide();
-                                  $("#tag-submit-btn").hide();
-                                  $("#tag-update-btn").show();
-                                  $('#tag-select').prop('disabled', true).select2({
-                                    width: '100%',
-                                    templateSelection: function (option) {
-                                      var color = $(option.element).data('custom-color');
-                                      return $('<span style="color: ' + color + '">' + option.text
-                                          + '</span>');
-                                    }
-                                  });
-                                  initializeTagSelect();
-                                });
-
-                                $('#tag-submit-btn').click(function () {
-                                  var selectedTags = $('#tag-select').val();
-
-                                  $.ajax({
-                                    url: '<%=request.getContextPath()%>/api/my-brand/tag',
-                                    method: 'POST',
-                                    contentType: 'application/json',
-                                    data: JSON.stringify({
-                                      'userSeq': ${userSeq},
-                                      'toTags': selectedTags
-                                    }),
-                                    success: function (response) {
-                                      alert('태그 변경에 성공하였습니다.');
-                                      $('#tag-select').prop('disabled', true).select2({
-                                        width: '100%',
-                                        templateSelection: function (option) {
-                                          var color = $(option.element).data('custom-color');
-                                          return $(
-                                              '<span style="color: ' + color + '">' + option.text
-                                              + '</span>');
-                                        }
-                                      });
-                                      $('#tag-submit-btn, #tag-cancel-btn').hide();
-                                      $('#tag-update-btn').show();
-                                      updateTagMessage();
-                                    },
-                                    error: function (err) {
-                                      alert('태그 변경에 실패하였습니다.');
-                                    }
-                                  });
-                                });
-
-                                initializeTagSelect();
-                              });
-                            </script>--%>
                             <script>
                               $(document).ready(function () {
                                 // Initialize the selectedTags array using EL
@@ -869,165 +783,268 @@
                                 });
                               });
                             </script>
-                            <%--
-                                                        <div class="row">
-                                                            <div class="col-lg-3 col-md-4 label">리뷰 로그</div>
-                                                            <div class="col-lg-8 col-md-6">
-                                                                <table class="table table-striped table-bordered text-center"
-                                                                       id="review-log-table">
-                                                                    <thead>
-                                                                    <tr>
-                                                                        <th>스토어명</th>
-                                                                        <th>방문일자</th>
-                                                                        <th>리뷰 작성여부</th>
-                                                                    </tr>
-                                                                    </thead>
-                                                                    <tbody>
-                                                                    <tr>
-                                                                        <th scope="row">1</th>
-                                                                        <td>Brandon Jacob</td>
-                                                                        <td>Designer</td>
-                                                                    </tr>
-                                                                    <tr>
-                                                                        <th scope="row">2</th>
-                                                                        <td>Bridie Kessler</td>
-                                                                        <td>Developer</td>
-                                                                    </tr>
-                                                                    <tr>
-                                                                        <th scope="row">3</th>
-                                                                        <td>Ashleigh Langosh</td>
-                                                                        <td>Finance</td>
-                                                                    </tr>
-                                                                    <tr>
-                                                                        <th scope="row">4</th>
-                                                                        <td>Angus Grady</td>
-                                                                        <td>HR</td>
-                                                                    </tr>
-                                                                    <tr>
-                                                                        <th scope="row">5</th>
-                                                                        <td>Raheem Lehner</td>
-                                                                        <td>Dynamic Division Officer</td>
-                                                                    </tr>
-                                                                    </tbody>
-                                                                </table>
-                                                                <div class="d-flex justify-content-between mt-3">
-                                                                    <button id="prev-block-button"
-                                                                            class="btn btn-primary edit-btn" disabled>&lt;
-                                                                    </button>
-                                                                    <div id="page-buttons"
-                                                                         class="d-flex justify-content-center mx-2">
-                                                                        <!-- 페이지 번호 버튼들이 여기에 추가됩니다 -->
-                                                                    </div>
-                                                                    <button id="next-block-button"
-                                                                            class="btn btn-primary edit-btn" disabled>&gt;
-                                                                    </button>
-                                                                </div>
-                                                            </div>
+                            <%--<div class="row">
+                                <div class="col-lg-3 col-md-4 label">리뷰 로그</div>
+                                <div class="col-lg-8 col-md-6">
+                                    <table class="table table-striped table-bordered text-center"
+                                           id="review-log-table">
+                                        <thead>
+                                        <tr>
+                                            <th>스토어명</th>
+                                            <th>방문일자</th>
+                                            <th>리뷰 작성여부</th>
+                                        </tr>
+                                        </thead>
+                                        <tbody>
+                                        <tr>
+                                            <th scope="row">1</th>
+                                            <td>Brandon Jacob</td>
+                                            <td>Designer</td>
+                                        </tr>
+                                        <tr>
+                                            <th scope="row">2</th>
+                                            <td>Bridie Kessler</td>
+                                            <td>Developer</td>
+                                        </tr>
+                                        <tr>
+                                            <th scope="row">3</th>
+                                            <td>Ashleigh Langosh</td>
+                                            <td>Finance</td>
+                                        </tr>
+                                        <tr>
+                                            <th scope="row">4</th>
+                                            <td>Angus Grady</td>
+                                            <td>HR</td>
+                                        </tr>
+                                        <tr>
+                                            <th scope="row">5</th>
+                                            <td>Raheem Lehner</td>
+                                            <td>Dynamic Division Officer</td>
+                                        </tr>
+                                        </tbody>
+                                    </table>--%>
+                            <div class="row">
+                                <div class="col-lg-3 col-md-4 label">리뷰 로그</div>
+                                <div class="col-lg-8 col-md-6">
+                                    <div class="table-container">
+                                        <table class="table table-striped table-bordered text-center"
+                                               id="review-log-table">
+                                            <thead>
+                                            <tr>
+                                                <th>스토어명</th>
+                                                <th>방문일자</th>
+                                                <th>리뷰 작성여부</th>
+                                            </tr>
+                                            </thead>
+                                            <tbody>
+                                            <c:forEach var="review" items="${reviewInfos}">
+                                                <c:set var="visitDate" value="${review.visitDate}"/>
+                                                <c:if test="${review.status == 'NOSHOW'}">
+                                                    <c:set var="visitDate" value="노쇼"/>
+                                                </c:if>
+                                                <tr>
+                                                    <td>
+                                                        <a href="/brand/${review.storeName}">${review.storeName}</a>
+                                                    </td>
+                                                    <td>${visitDate}</td>
+                                                    <td>
+                                                        <c:choose>
+                                                            <c:when test="${review.status == 'WRITTEN' || review.status == 'STORE_HIDDEN'}">
+                                                                <a href="${review.url}">O</a>
+                                                            </c:when>
+                                                            <c:when test="${review.status == 'UNWRITTEN'}">
+                                                                X
+                                                            </c:when>
+                                                            <c:when test="${review.status == 'NOSHOW'}">
+                                                                노쇼
+                                                            </c:when>
+                                                        </c:choose>
+                                                    </td>
+                                                </tr>
+                                            </c:forEach>
+                                            </tbody>
+                                        </table>
+                                        <%--<div class="alert alert-custom alert-custom-bottom"
+                                             role="alert">
+                                            노쇼한 리뷰는 제 3자에게 노출되지 않습니다.
+                                        </div>--%>
+                                        <div class="pagination-container">
+                                            <button id="prev-block-button"
+                                                    class="btn btn-primary edit-btn" disabled>&lt;
+                                            </button>
+                                            <div id="page-buttons"
+                                                 class="d-flex justify-content-center mx-2">
+                                                <!-- 페이지 번호 버튼들이 여기에 추가됩니다 -->
+                                            </div>
+                                            <button id="next-block-button"
+                                                    class="btn btn-primary edit-btn" disabled>&gt;
+                                            </button>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <%--<div class="row">
+                                <div class="col-lg-3 col-md-4 label">리뷰 로그</div>
+                                <div class="col-lg-8 col-md-6">
+                                    <div class="alert alert-custom" role="alert">
+                                        노쇼한 리뷰는 제 3자에게 노출되지 않습니다.
+                                    </div>
+                                    <table class="table table-striped table-bordered text-center"
+                                           id="review-log-table">
+                                        <thead>
+                                        <tr>
+                                            <th>스토어명</th>
+                                            <th>방문일자</th>
+                                            <th>리뷰 작성여부</th>
+                                        </tr>
+                                        </thead>
+                                        <tbody>
+                                        <c:forEach var="review" items="${reviewInfos}">
+                                            <c:set var="visitDate" value="${review.visitDate}"/>
+                                            <c:if test="${review.status == 'NOSHOW'}">
+                                                <c:set var="visitDate" value="노쇼"/>
+                                            </c:if>
+                                            <tr>
+                                                <td>
+                                                    <a href="/brand/${review.storeName}">${review.storeName}</a>
+                                                </td>
+                                                <td>${visitDate}</td>
+                                                <td>
+                                                    <c:choose>
+                                                        <c:when test="${review.status == 'WRITTEN' || review.status == 'STORE_HIDDEN'}">
+                                                            <a href="${review.url}">O</a>
+                                                        </c:when>
+                                                        <c:when test="${review.status == 'UNWRITTEN'}">
+                                                            X
+                                                        </c:when>
+                                                        <c:when test="${review.status == 'NOSHOW'}">
+                                                            노쇼
+                                                        </c:when>
+                                                    </c:choose>
+                                                </td>
+                                            </tr>
+                                        </c:forEach>
+                                        </tbody>
+                                    </table>
+                                    <div class="pagination-container">
+                                        <button id="prev-block-button"
+                                                class="btn btn-primary edit-btn" disabled>&lt;
+                                        </button>
+                                        <div id="page-buttons"
+                                             class="d-flex justify-content-center mx-2">
+                                            <!-- 페이지 번호 버튼들이 여기에 추가됩니다 -->
+                                        </div>
+                                        <button id="next-block-button"
+                                                class="btn btn-primary edit-btn" disabled>&gt;
+                                        </button>
+                                    </div>
+                                </div>
+                            </div>--%>
 
-                                                            <script>
-                                                              $(document).ready(function () {
-                                                                var currentPage = 1;
-                                                                var totalPages = 50; // 예시: 총 페이지 수는 50이라고 가정
-                                                                var pagesPerBlock = 5;
+                            <%-- <script>
+                               $(document).ready(function () {
+                                 var currentPage = 1;
+                                 var totalPages = 50; // 예시: 총 페이지 수는 50이라고 가정
+                                 var pagesPerBlock = 5;
 
-                                                                function fetchReviewLogs(page) {
-                                                                  $.ajax({
-                                                                    url: '/api/review-logs',
-                                                                    method: 'GET',
-                                                                    data: {page: page},
-                                                                    success: function (response) {
-                                                                      var reviewLogs = response.logs;
-                                                                      var hasPrevious = response.hasPrevious;
-                                                                      var hasNext = response.hasNext;
-                                                                      totalPages = response.totalPages;
+                                 function fetchReviewLogs(page) {
+                                   $.ajax({
+                                     url: '/api/review-logs',
+                                     method: 'GET',
+                                     data: {page: page},
+                                     success: function (response) {
+                                       var reviewLogs = response.logs;
+                                       var hasPrevious = response.hasPrevious;
+                                       var hasNext = response.hasNext;
+                                       totalPages = response.totalPages;
 
-                                                                      renderReviewLogs(reviewLogs);
-                                                                      renderPageButtons();
-                                                                      updatePaginationButtons(hasPrevious, hasNext);
-                                                                    },
-                                                                    error: function (err) {
-                                                                      alert('리뷰 로그 데이터를 가져오는데 실패하였습니다.');
-                                                                      renderPageButtons();
-                                                                    }
-                                                                  });
-                                                                }
+                                       renderReviewLogs(reviewLogs);
+                                       renderPageButtons();
+                                       updatePaginationButtons(hasPrevious, hasNext);
+                                     },
+                                     error: function (err) {
+                                       alert('리뷰 로그 데이터를 가져오는데 실패하였습니다.');
+                                       renderPageButtons();
+                                     }
+                                   });
+                                 }
 
-                                                                function renderReviewLogs(reviewLogs) {
-                                                                  var tbody = $('#review-log-table tbody');
-                                                                  tbody.empty(); // 기존 데이터를 제거합니다.
+                                 function renderReviewLogs(reviewLogs) {
+                                   var tbody = $('#review-log-table tbody');
+                                   tbody.empty(); // 기존 데이터를 제거합니다.
 
-                                                                  reviewLogs.forEach(function (log) {
-                                                                    var row = $('<tr>');
-                                                                    row.append($('<td>').text(log.storeName));
-                                                                    row.append($('<td>').text(log.visitDate));
-                                                                    row.append($('<td>').text(log.reviewWritten));
-                                                                    tbody.append(row);
-                                                                  });
-                                                                }
+                                   reviewLogs.forEach(function (log) {
+                                     var row = $('<tr>');
+                                     row.append($('<td>').text(log.storeName));
+                                     row.append($('<td>').text(log.visitDate));
+                                     row.append($('<td>').text(log.reviewWritten));
+                                     tbody.append(row);
+                                   });
+                                 }
 
-                                                                function renderPageButtons() {
-                                                                  var pageButtonsDiv = $('#page-buttons');
-                                                                  pageButtonsDiv.empty(); // 기존 페이지 버튼을 제거합니다.
+                                 function renderPageButtons() {
+                                   var pageButtonsDiv = $('#page-buttons');
+                                   pageButtonsDiv.empty(); // 기존 페이지 버튼을 제거합니다.
 
-                                                                  var currentBlock = Math.floor(
-                                                                      (currentPage - 1) / pagesPerBlock);
-                                                                  var startPage = currentBlock * pagesPerBlock + 1;
-                                                                  var endPage = Math.min(startPage + pagesPerBlock - 1,
-                                                                      totalPages);
+                                   var currentBlock = Math.floor(
+                                       (currentPage - 1) / pagesPerBlock);
+                                   var startPage = currentBlock * pagesPerBlock + 1;
+                                   var endPage = Math.min(startPage + pagesPerBlock - 1,
+                                       totalPages);
 
-                                                                  for (var i = startPage; i <= endPage; i++) {
-                                                                    var pageButton = $('<button>')
-                                                                    .text(i)
-                                                                    .addClass(
-                                                                        'btn btn-outline-primary mx-1 datatable-pagination-list-item-link')
-                                                                    .attr('data-page', i)
-                                                                    .attr('aria-label', 'Page ' + i);
-                                                                    if (i === currentPage) {
-                                                                      pageButton.addClass('active');
-                                                                    }
-                                                                    pageButton.on('click', function () {
-                                                                      var page = parseInt($(this).attr('data-page'));
-                                                                      currentPage = page;
-                                                                      fetchReviewLogs(currentPage);
-                                                                    });
-                                                                    pageButtonsDiv.append(pageButton);
-                                                                  }
-                                                                }
+                                   for (var i = startPage; i <= endPage; i++) {
+                                     var pageButton = $('<button>')
+                                     .text(i)
+                                     .addClass(
+                                         'btn btn-outline-primary mx-1 datatable-pagination-list-item-link')
+                                     .attr('data-page', i)
+                                     .attr('aria-label', 'Page ' + i);
+                                     if (i === currentPage) {
+                                       pageButton.addClass('active');
+                                     }
+                                     pageButton.on('click', function () {
+                                       var page = parseInt($(this).attr('data-page'));
+                                       currentPage = page;
+                                       fetchReviewLogs(currentPage);
+                                     });
+                                     pageButtonsDiv.append(pageButton);
+                                   }
+                                 }
 
-                                                                function updatePaginationButtons(hasPrevious, hasNext) {
-                                                                  var currentBlock = Math.floor(
-                                                                      (currentPage - 1) / pagesPerBlock);
-                                                                  var totalBlocks = Math.ceil(totalPages / pagesPerBlock);
+                                 function updatePaginationButtons(hasPrevious, hasNext) {
+                                   var currentBlock = Math.floor(
+                                       (currentPage - 1) / pagesPerBlock);
+                                   var totalBlocks = Math.ceil(totalPages / pagesPerBlock);
 
-                                                                  $('#prev-block-button').prop('disabled', currentBlock === 0);
-                                                                  $('#next-block-button').prop('disabled',
-                                                                      currentBlock >= totalBlocks - 1);
-                                                                }
+                                   $('#prev-block-button').prop('disabled', currentBlock === 0);
+                                   $('#next-block-button').prop('disabled',
+                                       currentBlock >= totalBlocks - 1);
+                                 }
 
-                                                                $('#prev-block-button').click(function () {
-                                                                  var currentBlock = Math.floor(
-                                                                      (currentPage - 1) / pagesPerBlock);
-                                                                  if (currentBlock > 0) {
-                                                                    currentPage = (currentBlock - 1) * pagesPerBlock + 1;
-                                                                    fetchReviewLogs(currentPage);
-                                                                  }
-                                                                });
+                                 $('#prev-block-button').click(function () {
+                                   var currentBlock = Math.floor(
+                                       (currentPage - 1) / pagesPerBlock);
+                                   if (currentBlock > 0) {
+                                     currentPage = (currentBlock - 1) * pagesPerBlock + 1;
+                                     fetchReviewLogs(currentPage);
+                                   }
+                                 });
 
-                                                                $('#next-block-button').click(function () {
-                                                                  var currentBlock = Math.floor(
-                                                                      (currentPage - 1) / pagesPerBlock);
-                                                                  var totalBlocks = Math.ceil(totalPages / pagesPerBlock);
-                                                                  if (currentBlock < totalBlocks - 1) {
-                                                                    currentPage = (currentBlock + 1) * pagesPerBlock + 1;
-                                                                    fetchReviewLogs(currentPage);
-                                                                  }
-                                                                });
+                                 $('#next-block-button').click(function () {
+                                   var currentBlock = Math.floor(
+                                       (currentPage - 1) / pagesPerBlock);
+                                   var totalBlocks = Math.ceil(totalPages / pagesPerBlock);
+                                   if (currentBlock < totalBlocks - 1) {
+                                     currentPage = (currentBlock + 1) * pagesPerBlock + 1;
+                                     fetchReviewLogs(currentPage);
+                                   }
+                                 });
 
-                                                                // 초기 데이터 로드
-                                                                fetchReviewLogs(currentPage);
-                                                              });
+                                 // 초기 데이터 로드
+                                 fetchReviewLogs(currentPage);
+                               });
 
-                                                            </script>--%>
+                             </script>--%>
 
 
 </main><!-- End #main -->


### PR DESCRIPTION
1. 리뷰 로그는
- 스토어명, 방문일자, 리뷰 상태로 이루어집니다.

<img width="732" alt="스크린샷 2024-07-21 오후 7 44 38" src="https://github.com/user-attachments/assets/74443b1d-25f4-489b-bdd7-58665064660b">

2. 노쇼한 리뷰는, 회색 버튼으로 "노쇼"라 나오고,
리뷰를 작성한 경우, 초록색 버튼으로 "리뷰 확인"이라 나옵니다.
리뷰를 아직 등록하지 않은 경우, 빨간색 버튼으로 "리뷰 등록하기" 버튼이 나옵니다.

- "리뷰 확인" 클릭 시, 등록한 리뷰 URL로 이동합니다.
<img width="652" alt="스크린샷 2024-07-21 오후 7 46 12" src="https://github.com/user-attachments/assets/cd4a7e7d-7f4b-4e59-91c0-169ccc6811b6">



3. 페이지네이션 기능을 구현했습니다.

- 테스트에 사용된 체험단의 리뷰는 74개이고,
체험단 본인은 자신의 '노쇼' 처리된 리뷰를 볼 수 있게 했습니다.

<img width="690" alt="스크린샷 2024-07-21 오후 7 46 38" src="https://github.com/user-attachments/assets/b4ce87b9-2ce4-4982-9ae8-ab98e4beb438">

- "<" 버튼, ">" 버튼을 통해 이전 페이지, 다음 페이지로 이동 가능합니다.


<img width="696" alt="스크린샷 2024-07-21 오후 7 47 44" src="https://github.com/user-attachments/assets/a81adb8c-f8fe-43ef-82a9-4779f90b16ba">

<img width="682" alt="스크린샷 2024-07-21 오후 7 48 20" src="https://github.com/user-attachments/assets/8c57647a-8bfb-4b1a-95c1-d612955ff044">

- 최종 페이지 15페이지에서 리뷰가 4개 ( 14*5 + 4 = 74 ) 개 나옴을 확인할 수 있습니다.


4. "리뷰 등록하기" 버튼을 누르면,
리뷰 등록 관련 모달창이 띄워집니다.

<img width="686" alt="스크린샷 2024-07-21 오후 7 49 02" src="https://github.com/user-attachments/assets/c5cfb44e-21ec-4c34-80ab-add90c8d8073">

- 등록을 누르면 등록 완료됩니다.

<img width="731" alt="스크린샷 2024-07-21 오후 7 49 36" src="https://github.com/user-attachments/assets/40fc128f-b097-4b2b-b2fd-eb897fb9b6a4">

- 등록 완료 시, 뷰가 "리뷰 확인" 버튼으로 업데이트 됩니다.

- 이미 등록한 리뷰에 대해 다시 리뷰를 등록하려 하면,
등록 불가하다는 alert 창을 띄워줍니다.

<img width="726" alt="스크린샷 2024-07-21 오후 7 50 35" src="https://github.com/user-attachments/assets/7750be3e-e340-4a32-9092-58400e92c580">

- URL 형식이 아닌 리뷰를 입력하면, 예외처리 해줍니다.

<img width="734" alt="스크린샷 2024-07-21 오후 7 51 03" src="https://github.com/user-attachments/assets/d7f476a1-8370-4d66-bda8-6a595befbda4">

