### PR TITLE
[feat-admin] 유저 별 받은 찜 개수 누계 시스템 구현

### DIFF
--- a/src/main/java/com/nuguna/freview/admin/mapper/ZzimAccumulationMapper.java
+++ b/src/main/java/com/nuguna/freview/admin/mapper/ZzimAccumulationMapper.java
@@ -1,0 +1,11 @@
+package com.nuguna.freview.admin.mapper;
+
+import com.nuguna.freview.admin.vo.ZzimAccumulationVO;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface ZzimAccumulationMapper {
+  ZzimAccumulationVO getByUserSeq(Long userSeq);
+  void insert(ZzimAccumulationVO zzimAccumulation);
+  void update(ZzimAccumulationVO zzimAccumulation);
+}

--- a/src/main/java/com/nuguna/freview/admin/mapper/ZzimLogMapper.java
+++ b/src/main/java/com/nuguna/freview/admin/mapper/ZzimLogMapper.java
@@ -3,8 +3,10 @@ package com.nuguna.freview.admin.mapper;
 import com.nuguna.freview.admin.vo.ZzimLogVO;
 import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 @Mapper
 public interface ZzimLogMapper {
   List<ZzimLogVO> getNewLogs(Long lastProcessedSeq);
+  int insertZzimLog(@Param("fromUserSeq") Long fromUseSeq, @Param("toUserSeq") Long toUserSeq, @Param("code") String code);
 }

--- a/src/main/java/com/nuguna/freview/admin/mapper/ZzimLogMapper.java
+++ b/src/main/java/com/nuguna/freview/admin/mapper/ZzimLogMapper.java
@@ -1,0 +1,10 @@
+package com.nuguna.freview.admin.mapper;
+
+import com.nuguna.freview.admin.vo.ZzimLogVO;
+import java.util.List;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface ZzimLogMapper {
+  List<ZzimLogVO> getNewLogs(Long lastProcessedSeq);
+}

--- a/src/main/java/com/nuguna/freview/admin/mapper/ZzimPostprocessingLogMapper.java
+++ b/src/main/java/com/nuguna/freview/admin/mapper/ZzimPostprocessingLogMapper.java
@@ -1,0 +1,9 @@
+package com.nuguna.freview.admin.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface ZzimPostprocessingLogMapper {
+  Long getLastProcessedSeq();
+  void updateLastProcessedSeq(Long seq);
+}

--- a/src/main/java/com/nuguna/freview/admin/service/ZzimLogService.java
+++ b/src/main/java/com/nuguna/freview/admin/service/ZzimLogService.java
@@ -1,0 +1,63 @@
+package com.nuguna.freview.admin.service;
+
+import com.nuguna.freview.admin.mapper.ZzimAccumulationMapper;
+import com.nuguna.freview.admin.mapper.ZzimLogMapper;
+import com.nuguna.freview.admin.mapper.ZzimPostprocessingLogMapper;
+import com.nuguna.freview.admin.vo.ZzimAccumulationVO;
+import com.nuguna.freview.admin.vo.ZzimLogVO;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+public class ZzimLogService {
+
+  private final ZzimLogMapper zzimLogMapper;
+  private final ZzimAccumulationMapper zzimAccumulationMapper;
+  private final ZzimPostprocessingLogMapper zzimPostprocessingLogMapper;
+
+  @Autowired
+  public ZzimLogService(ZzimLogMapper zzimLogMapper, ZzimAccumulationMapper zzimAccumulationMapper,
+      ZzimPostprocessingLogMapper zzimPostprocessingLogMapper) {
+    this.zzimLogMapper = zzimLogMapper;
+    this.zzimAccumulationMapper = zzimAccumulationMapper;
+    this.zzimPostprocessingLogMapper = zzimPostprocessingLogMapper;
+  }
+
+  @Scheduled(fixedRate = 1000)
+  @Transactional
+  public void zzimLogsProcess() {
+    Long lastProcessedSeq = zzimPostprocessingLogMapper.getLastProcessedSeq();
+    if (lastProcessedSeq == null) {
+      lastProcessedSeq = 0L;
+    }
+
+    List<ZzimLogVO> newLogs = zzimLogMapper.getNewLogs(lastProcessedSeq);
+
+    if (!newLogs.isEmpty()) {
+      Map<Long, Long> zzimCounts = newLogs.stream()
+          .collect(Collectors.groupingBy(ZzimLogVO::getToUserSeq,
+              Collectors.summingLong(log -> log.getCode().equals("ZZIM") ? 1L : -1L)));
+
+      zzimCounts.forEach((toUserSeq, count) -> {
+        ZzimAccumulationVO currentAccumulation = zzimAccumulationMapper.getByUserSeq(toUserSeq);
+        if (currentAccumulation == null) {
+          currentAccumulation = new ZzimAccumulationVO(toUserSeq, count);
+          zzimAccumulationMapper.insert(currentAccumulation);
+        } else {
+          currentAccumulation.updateTotalZzim(currentAccumulation.getTotalZzim() + count);
+          zzimAccumulationMapper.update(currentAccumulation);
+        }
+      });
+
+      Long maxSeq = newLogs.stream().mapToLong(ZzimLogVO::getSeq).max().getAsLong();
+      zzimPostprocessingLogMapper.updateLastProcessedSeq(maxSeq);
+    }
+  }
+}

--- a/src/main/java/com/nuguna/freview/admin/vo/ZzimAccumulationVO.java
+++ b/src/main/java/com/nuguna/freview/admin/vo/ZzimAccumulationVO.java
@@ -1,0 +1,15 @@
+package com.nuguna.freview.admin.vo;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ZzimAccumulationVO {
+  private Long userSeq;
+  private Long totalZzim;
+
+  public void updateTotalZzim(Long newTotal) {
+    this.totalZzim = newTotal;
+  }
+}

--- a/src/main/java/com/nuguna/freview/admin/vo/ZzimLogVO.java
+++ b/src/main/java/com/nuguna/freview/admin/vo/ZzimLogVO.java
@@ -1,0 +1,12 @@
+package com.nuguna.freview.admin.vo;
+
+import lombok.Getter;
+
+@Getter
+public class ZzimLogVO {
+
+  private Long seq;
+  private Long fromUserSeq;
+  private Long toUserSeq;
+  private String code;
+}

--- a/src/main/resources/mappers/admin/zzim-accumulation-map.xml
+++ b/src/main/resources/mappers/admin/zzim-accumulation-map.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.nuguna.freview.admin.mapper.ZzimAccumulationMapper">
+
+  <!-- ZzimAccumulationVO resultMap -->
+  <resultMap id="zzimAccumulationResultMap" type="com.nuguna.freview.admin.vo.ZzimAccumulationVO">
+    <id property="userSeq" column="user_seq" />
+    <result property="totalZzim" column="total_zzim" />
+  </resultMap>
+
+  <select id="getByUserSeq" resultMap="zzimAccumulationResultMap">
+    SELECT user_seq, total_zzim FROM zzim_accumulation
+    WHERE user_seq = #{userSeq}
+  </select>
+
+  <insert id="insert">
+    INSERT INTO zzim_accumulation (user_seq, total_zzim)
+    VALUES (#{userSeq}, #{totalZzim})
+  </insert>
+
+  <update id="update">
+    UPDATE zzim_accumulation
+    SET total_zzim = #{totalZzim}
+    WHERE user_seq = #{userSeq}
+  </update>
+
+</mapper>

--- a/src/main/resources/mappers/admin/zzim-log-map.xml
+++ b/src/main/resources/mappers/admin/zzim-log-map.xml
@@ -19,4 +19,9 @@
     limit 100
   </select>
 
+  <insert id="insertZzimLog" parameterType="map">
+    insert into zzim_log (from_user_seq, to_user_seq, code)
+    values (#{fromUserSeq}, #{toUseSeq}, #{code})
+  </insert>
+
 </mapper>

--- a/src/main/resources/mappers/admin/zzim-log-map.xml
+++ b/src/main/resources/mappers/admin/zzim-log-map.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.nuguna.freview.admin.mapper.ZzimLogMapper">
+
+  <!-- ZzimLogVO resultMap -->
+  <resultMap id="zzimLogResultMap" type="com.nuguna.freview.admin.vo.ZzimLogVO">
+    <id property="seq" column="seq" />
+    <result property="fromUserSeq" column="from_user_seq" />
+    <result property="toUserSeq" column="to_user_seq" />
+    <result property="code" column="code" />
+  </resultMap>
+
+  <select id="getNewLogs" resultMap="zzimLogResultMap">
+    SELECT seq, from_user_seq, to_user_seq, code
+    FROM zzim_log
+    WHERE seq > #{lastProcessedSeq}
+    limit 100
+  </select>
+
+</mapper>

--- a/src/main/resources/mappers/admin/zzim-postprocessing-log-map.xml
+++ b/src/main/resources/mappers/admin/zzim-postprocessing-log-map.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.nuguna.freview.admin.mapper.ZzimPostprocessingLogMapper">
+
+  <select id="getLastProcessedSeq" resultType="long">
+    SELECT last_processed_zzim_seq
+    FROM zzim_postprocessing_log
+    ORDER BY seq DESC
+    limit 1
+  </select>
+
+  <insert id="updateLastProcessedSeq">
+    INSERT into zzim_postprocessing_log (last_processed_zzim_seq)
+    VALUES (#{seq})
+  </insert>
+
+</mapper>


### PR DESCRIPTION
### [목적]
* 유저 간 찜 관련 액션 (추가 / 취소) 에 대해 로그를 쌓아 유저 간 받은 찜 개수 누계 테이블을 운용할 수 있음

* 체험단 / 사장님 브랜딩 페이지에서 해당 누계 테이블에서 유저 별 찜 수를 추출할 수 있음
찜 추가 / 삭제 로직에 ZzimLogMapper의 insertZzimLog 메서드 활용 로직 추가 필요 (@체험단 / @사장님)
<img width="910" alt="image" src="https://github.com/user-attachments/assets/6b5790d9-0734-46be-9f94-9bd82d465914">
- 찜 추가 시 code = ZZIM   <br>
- 찜 삭제 시 code = DISZZIM  <br>
 <br>
<예시 - 게시글에 좋아요를 추가하는 서비스 로직과 게시글 좋아요 로그를 추가하는 서비스 로직이 트랜잭션으로 묶여있는 모습>
<img width="548" alt="image" src="https://github.com/user-attachments/assets/13785bb1-fd96-435e-b207-2ffb79a80fcc">


### [로직]
* zzim_log의 (찜 추가 / 찜 삭제) 기록을 점수화하여 accumulation 테이블에 합산 적용