### PR TITLE
[feat-admin] 일 별 성사된 체험 횟수 누계 시스템 구현

### DIFF
--- a/src/main/java/com/nuguna/freview/admin/dto/DoneExperienceDTO.java
+++ b/src/main/java/com/nuguna/freview/admin/dto/DoneExperienceDTO.java
@@ -1,0 +1,15 @@
+package com.nuguna.freview.admin.dto;
+
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class DoneExperienceDTO {
+
+  private LocalDate date;
+  private Long totalDone;
+}

--- a/src/main/java/com/nuguna/freview/admin/dto/DoneExperienceLogDTO.java
+++ b/src/main/java/com/nuguna/freview/admin/dto/DoneExperienceLogDTO.java
@@ -1,0 +1,11 @@
+package com.nuguna.freview.admin.dto;
+
+import java.time.LocalDate;
+import lombok.Getter;
+
+@Getter
+public class DoneExperienceLogDTO {
+
+  private Long seq;
+  private LocalDate visitDate;
+}

--- a/src/main/java/com/nuguna/freview/admin/dto/NoShowExperienceLogDTO.java
+++ b/src/main/java/com/nuguna/freview/admin/dto/NoShowExperienceLogDTO.java
@@ -3,7 +3,7 @@ package com.nuguna.freview.admin.dto;
 import lombok.Getter;
 
 @Getter
-public class ExperienceLogDTO {
+public class NoShowExperienceLogDTO {
 
   private Long seq;
   private Long fromUserSeq;

--- a/src/main/java/com/nuguna/freview/admin/mapper/DoneExperienceAccumulationMapper.java
+++ b/src/main/java/com/nuguna/freview/admin/mapper/DoneExperienceAccumulationMapper.java
@@ -1,0 +1,13 @@
+package com.nuguna.freview.admin.mapper;
+
+import com.nuguna.freview.admin.dto.DoneExperienceDTO;
+import java.time.LocalDate;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface DoneExperienceAccumulationMapper {
+
+  DoneExperienceDTO findByDate(LocalDate date);
+  void insert(DoneExperienceDTO record);
+  void update(DoneExperienceDTO record);
+}

--- a/src/main/java/com/nuguna/freview/admin/mapper/ExperienceMapper.java
+++ b/src/main/java/com/nuguna/freview/admin/mapper/ExperienceMapper.java
@@ -1,11 +1,14 @@
 package com.nuguna.freview.admin.mapper;
 
-import com.nuguna.freview.admin.dto.ExperienceLogDTO;
+import com.nuguna.freview.admin.dto.DoneExperienceLogDTO;
+import com.nuguna.freview.admin.dto.NoShowExperienceLogDTO;
 import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 @Mapper
 public interface ExperienceMapper {
 
-  List<ExperienceLogDTO> selectExperiencesToNoShow(Long lastProcessedSeq);
+  List<NoShowExperienceLogDTO> selectNoShowExperiences(@Param("lastProcessedSeq") Long lastProcessedSeq, @Param("status") String status);
+  List<DoneExperienceLogDTO> selectDoneExperiences(@Param("lastProcessedSeq") Long lastProcessedSeq, @Param("status") String status);
 }

--- a/src/main/java/com/nuguna/freview/admin/mapper/ExperiencePostProcessingLogMapper.java
+++ b/src/main/java/com/nuguna/freview/admin/mapper/ExperiencePostProcessingLogMapper.java
@@ -1,10 +1,11 @@
 package com.nuguna.freview.admin.mapper;
 
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 @Mapper
 public interface ExperiencePostProcessingLogMapper {
 
-  void updateLastProcessedSeq(Long seq);
-  Long getLastProcessedSeq();
+  void updateLastProcessedSeq(@Param("purpose") String purpose, @Param("seq") Long seq);
+  Long getLastProcessedSeq(String purpose);
 }

--- a/src/main/java/com/nuguna/freview/admin/service/ExperienceLogService.java
+++ b/src/main/java/com/nuguna/freview/admin/service/ExperienceLogService.java
@@ -1,10 +1,16 @@
 package com.nuguna.freview.admin.service;
 
-import com.nuguna.freview.admin.dto.ExperienceLogDTO;
+import com.nuguna.freview.admin.dto.DoneExperienceDTO;
+import com.nuguna.freview.admin.dto.DoneExperienceLogDTO;
+import com.nuguna.freview.admin.dto.NoShowExperienceLogDTO;
+import com.nuguna.freview.admin.mapper.DoneExperienceAccumulationMapper;
 import com.nuguna.freview.admin.mapper.ExperienceMapper;
 import com.nuguna.freview.admin.mapper.ExperiencePostProcessingLogMapper;
 import com.nuguna.freview.admin.mapper.NoshowAccumulationMapper;
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -18,37 +24,85 @@ public class ExperienceLogService {
   private final ExperienceMapper experienceMapper;
   private final NoshowAccumulationMapper noshowAccumulationMapper;
   private final ExperiencePostProcessingLogMapper experiencePostProcessingLogMapper;
+  private final DoneExperienceAccumulationMapper doneExperienceAccumulationMapper;
 
   @Autowired
-  public ExperienceLogService(ExperienceMapper experienceMapper, NoshowAccumulationMapper noshowAccumulationMapper,
-      ExperiencePostProcessingLogMapper experiencePostProcessingLogMapper) {
+  public ExperienceLogService(ExperienceMapper experienceMapper,
+      NoshowAccumulationMapper noshowAccumulationMapper,
+      ExperiencePostProcessingLogMapper experiencePostProcessingLogMapper,
+      DoneExperienceAccumulationMapper doneExperienceAccumulationMapper) {
     this.experienceMapper = experienceMapper;
     this.noshowAccumulationMapper = noshowAccumulationMapper;
     this.experiencePostProcessingLogMapper = experiencePostProcessingLogMapper;
+    this.doneExperienceAccumulationMapper = doneExperienceAccumulationMapper;
   }
 
   @Scheduled(cron = "0 0 12,0 * * *")
   @Transactional
   public void processNoShowExperiences() {
-
-    Long lastProcessedSeq = experiencePostProcessingLogMapper.getLastProcessedSeq();
+    String purpose = "NOSHOW_ACCUMULATION";
+    String status = "NOSHOW";
+    Long lastProcessedSeq = experiencePostProcessingLogMapper.getLastProcessedSeq(purpose);
     if (lastProcessedSeq == null) {
       lastProcessedSeq = 0L;
     }
 
-    List<ExperienceLogDTO> experiences = experienceMapper.selectExperiencesToNoShow(lastProcessedSeq);
+    List<NoShowExperienceLogDTO> experiences = experienceMapper.selectNoShowExperiences(
+        lastProcessedSeq, status);
 
     if (!experiences.isEmpty()) {
       experiences.forEach(experience -> {
-        Long userSeqForAccumulation = (experience.getFromPostSeq() == null) ? experience.getToUserSeq() : experience.getFromUserSeq();
+        Long userSeqForAccumulation =
+            (experience.getFromPostSeq() == null) ? experience.getToUserSeq()
+                : experience.getFromUserSeq();
         int rowUpdated = noshowAccumulationMapper.updateNoshowAccumulation(userSeqForAccumulation);
         if (rowUpdated == 0) {
           noshowAccumulationMapper.insertNoshowAccumulation(userSeqForAccumulation);
         }
       });
 
-      Long maxSeq = experiences.stream().mapToLong(ExperienceLogDTO::getSeq).max().getAsLong();
-      experiencePostProcessingLogMapper.updateLastProcessedSeq(maxSeq);
+      Long maxSeq = experiences.stream()
+          .mapToLong(NoShowExperienceLogDTO::getSeq)
+          .max()
+          .getAsLong();
+      experiencePostProcessingLogMapper.updateLastProcessedSeq(purpose, maxSeq);
+    }
+  }
+
+  @Scheduled(cron = "0 0 12,0 * * *")
+  @Transactional
+  public void processDoneExperiences() {
+    String purpose = "DONE_EXPERIENCE_ACCUMULATION";
+    String status = "DONE";
+    Long lastProcessedSeq = experiencePostProcessingLogMapper.getLastProcessedSeq(purpose);
+    if (lastProcessedSeq == null) {
+      lastProcessedSeq = 0L;
+    }
+
+    List<DoneExperienceLogDTO> experiences = experienceMapper.selectDoneExperiences(
+        lastProcessedSeq, status);
+    if (!experiences.isEmpty()) {
+      Map<LocalDate, Long> dailyCounts = experiences.stream()
+          .collect(Collectors.groupingBy(
+              experience -> experience.getVisitDate(),
+              Collectors.counting()
+          ));
+
+      dailyCounts.forEach((date, count) -> {
+        DoneExperienceDTO existingRecord = doneExperienceAccumulationMapper.findByDate(date);
+        if (existingRecord == null) {
+          doneExperienceAccumulationMapper.insert(new DoneExperienceDTO(date, count));
+        } else {
+          existingRecord.setTotalDone(existingRecord.getTotalDone() + count);
+          doneExperienceAccumulationMapper.update(existingRecord);
+        }
+      });
+
+      Long maxSeq = experiences.stream()
+          .mapToLong(DoneExperienceLogDTO::getSeq)
+          .max()
+          .getAsLong();
+      experiencePostProcessingLogMapper.updateLastProcessedSeq(purpose, maxSeq);
     }
   }
 }

--- a/src/main/java/com/nuguna/freview/admin/service/ExperienceLogService.java
+++ b/src/main/java/com/nuguna/freview/admin/service/ExperienceLogService.java
@@ -27,9 +27,9 @@ public class ExperienceLogService {
     this.experiencePostProcessingLogMapper = experiencePostProcessingLogMapper;
   }
 
-  @Scheduled(fixedRate = 1000)
+  @Scheduled(cron = "0 0 12,0 * * *")
   @Transactional
-  public void processExperiences() {
+  public void processNoShowExperiences() {
 
     Long lastProcessedSeq = experiencePostProcessingLogMapper.getLastProcessedSeq();
     if (lastProcessedSeq == null) {

--- a/src/main/resources/mappers/admin/done-experience-accumulation-map.xml
+++ b/src/main/resources/mappers/admin/done-experience-accumulation-map.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.nuguna.freview.admin.mapper.DoneExperienceAccumulationMapper">
+
+  <resultMap id="doneExperienceResultMap" type="com.nuguna.freview.admin.dto.DoneExperienceDTO">
+    <result property="date" column="created_at" javaType="java.time.LocalDate"/>
+    <result property="totalCount" column="total_count"/>
+  </resultMap>
+
+  <select id="findByDate" resultMap="doneExperienceResultMap">
+    SELECT date, total_count
+    FROM done_experience_accumulation
+    WHERE date = #{date}
+  </select>
+
+  <insert id="insert">
+    INSERT INTO done_experience_accumulation (date, total_count)
+    VALUES (#{date}, #{totalDone})
+  </insert>
+
+  <update id="update">
+    UPDATE done_experience_accumulation
+    SET total_count = #{totalDone}
+    WHERE date = #{date}
+  </update>
+
+</mapper>

--- a/src/main/resources/mappers/admin/experience-map.xml
+++ b/src/main/resources/mappers/admin/experience-map.xml
@@ -5,8 +5,8 @@
 <mapper namespace="com.nuguna.freview.admin.mapper.ExperienceMapper">
 
   <!-- resultMap -->
-  <!-- Experience resultMap -->
-  <resultMap id="experienceResultMap" type="com.nuguna.freview.admin.dto.ExperienceLogDTO">
+  <!-- noshow resultMap -->
+  <resultMap id="noShowExperienceResultMap" type="com.nuguna.freview.admin.dto.NoShowExperienceLogDTO">
     <id property="seq" column="seq"/>
     <result property="fromUserSeq" column="from_user_seq"/>
     <result property="toUserSeq" column="to_user_seq"/>
@@ -14,11 +14,25 @@
     <result property="status" column="status"/>
   </resultMap>
 
+  <resultMap id="DoneExperienceResultMap" type="com.nuguna.freview.admin.dto.DoneExperienceLogDTO">
+    <id property="seq" column="seq"/>
+    <result property="visitDate" column="visit_date" javaType="java.time.LocalDate" jdbcType="TIMESTAMP"/>
+  </resultMap>
+
   <!-- 'NOSHOW'인 experience 데이터 조회 -->
-  <select id="selectExperiencesToNoShow" parameterType="long" resultMap="experienceResultMap">
+  <select id="selectNoShowExperiences" parameterType="map" resultMap="noShowExperienceResultMap">
     SELECT seq, from_user_seq, to_user_seq, from_post_seq, status
     FROM experience
-    WHERE status = 'NOSHOW' AND seq > #{lastProcessedSeq}
+    WHERE status = #{status} AND seq > #{lastProcessedSeq}
+    ORDER BY seq ASC
+    LIMIT 100
+  </select>
+
+  <!-- 'DONE'인 experience 데이터 조회 -->
+  <select id="selectDoneExperiences" parameterType="map" resultMap="DoneExperienceResultMap">
+    SELECT seq, visit_date
+    FROM experience
+    WHERE status = #{status} AND seq > #{lastProcessedSeq}
     ORDER BY seq ASC
     LIMIT 100
   </select>

--- a/src/main/resources/mappers/admin/experience-postprocessing-log-map.xml
+++ b/src/main/resources/mappers/admin/experience-postprocessing-log-map.xml
@@ -5,16 +5,16 @@
 <mapper namespace="com.nuguna.freview.admin.mapper.ExperiencePostProcessingLogMapper">
 
   <!-- 마지막으로 처리한 seq 로깅 -->
-  <insert id="updateLastProcessedSeq" parameterType="long">
+  <insert id="updateLastProcessedSeq" parameterType="map">
     insert into experience_postprocessing_log (last_processed_seq, purpose)
-    values (#{seq}, 'NOSHOW_ACCUMULATION')
+    values (#{seq}, #{purpose})
   </insert>
 
   <!-- 최근 처리된 작업 번호 가져오기 -->
-  <select id="getLastProcessedSeq" resultType="long">
+  <select id="getLastProcessedSeq" parameterType="map" resultType="long">
     SELECT last_processed_seq
     FROM experience_postprocessing_log
-    WHERE purpose = 'NOSHOW_ACCUMULATION'
+    WHERE purpose = #{purpose}
     order by seq DESC
     limit 1
   </select>


### PR DESCRIPTION
### [목적]
- 일 별 성사된 체험 수를 주기적으로 업데이트하여 누계 테이블을 운용할 수 있음
- 관리자의 사용자 분석 대시보드에서 일 별 성사된 체험 횟수 정보를 확인할 수 있음

### [로직]
- 12시 / 24시에 스케줄러를 통해 experience 테이블의 기록을 accumulation 테이블에 합산하여 적용
