### PR TITLE
[feat-admin] 유저 별 랭킹 포인트 누계 시스템 구현

### DIFF
--- a/src/main/java/com/nuguna/freview/admin/dto/DoneExperienceDTO.java
+++ b/src/main/java/com/nuguna/freview/admin/dto/DoneExperienceDTO.java
@@ -1,0 +1,15 @@
+package com.nuguna.freview.admin.dto;
+
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class DoneExperienceDTO {
+
+  private LocalDate date;
+  private Long totalDone;
+}

--- a/src/main/java/com/nuguna/freview/admin/dto/DoneExperienceLogDTO.java
+++ b/src/main/java/com/nuguna/freview/admin/dto/DoneExperienceLogDTO.java
@@ -1,0 +1,11 @@
+package com.nuguna.freview.admin.dto;
+
+import java.time.LocalDate;
+import lombok.Getter;
+
+@Getter
+public class DoneExperienceLogDTO {
+
+  private Long seq;
+  private LocalDate visitDate;
+}

--- a/src/main/java/com/nuguna/freview/admin/dto/NoShowExperienceLogDTO.java
+++ b/src/main/java/com/nuguna/freview/admin/dto/NoShowExperienceLogDTO.java
@@ -3,7 +3,7 @@ package com.nuguna.freview.admin.dto;
 import lombok.Getter;
 
 @Getter
-public class ExperienceLogDTO {
+public class NoShowExperienceLogDTO {
 
   private Long seq;
   private Long fromUserSeq;

--- a/src/main/java/com/nuguna/freview/admin/mapper/DoneExperienceAccumulationMapper.java
+++ b/src/main/java/com/nuguna/freview/admin/mapper/DoneExperienceAccumulationMapper.java
@@ -1,0 +1,13 @@
+package com.nuguna.freview.admin.mapper;
+
+import com.nuguna.freview.admin.dto.DoneExperienceDTO;
+import java.time.LocalDate;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface DoneExperienceAccumulationMapper {
+
+  DoneExperienceDTO findByDate(LocalDate date);
+  void insert(DoneExperienceDTO record);
+  void update(DoneExperienceDTO record);
+}

--- a/src/main/java/com/nuguna/freview/admin/mapper/ExperienceMapper.java
+++ b/src/main/java/com/nuguna/freview/admin/mapper/ExperienceMapper.java
@@ -1,11 +1,14 @@
 package com.nuguna.freview.admin.mapper;
 
-import com.nuguna.freview.admin.dto.ExperienceLogDTO;
+import com.nuguna.freview.admin.dto.DoneExperienceLogDTO;
+import com.nuguna.freview.admin.dto.NoShowExperienceLogDTO;
 import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 @Mapper
 public interface ExperienceMapper {
 
-  List<ExperienceLogDTO> selectExperiencesToNoShow(Long lastProcessedSeq);
+  List<NoShowExperienceLogDTO> selectNoShowExperiences(@Param("lastProcessedSeq") Long lastProcessedSeq, @Param("status") String status);
+  List<DoneExperienceLogDTO> selectDoneExperiences(@Param("lastProcessedSeq") Long lastProcessedSeq, @Param("status") String status);
 }

--- a/src/main/java/com/nuguna/freview/admin/mapper/ExperiencePostProcessingLogMapper.java
+++ b/src/main/java/com/nuguna/freview/admin/mapper/ExperiencePostProcessingLogMapper.java
@@ -1,10 +1,11 @@
 package com.nuguna.freview.admin.mapper;
 
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 @Mapper
 public interface ExperiencePostProcessingLogMapper {
 
-  void updateLastProcessedSeq(Long seq);
-  Long getLastProcessedSeq();
+  void updateLastProcessedSeq(@Param("purpose") String purpose, @Param("seq") Long seq);
+  Long getLastProcessedSeq(String purpose);
 }

--- a/src/main/java/com/nuguna/freview/admin/mapper/RankPointAccumulationMapper.java
+++ b/src/main/java/com/nuguna/freview/admin/mapper/RankPointAccumulationMapper.java
@@ -1,0 +1,12 @@
+package com.nuguna.freview.admin.mapper;
+
+import com.nuguna.freview.admin.vo.PointAccumulationVO;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface RankPointAccumulationMapper {
+
+  PointAccumulationVO getByUserSeq(Long userSeq);
+  void insert(PointAccumulationVO pointAccumulation);
+  void update(PointAccumulationVO pointAccumulation);
+}

--- a/src/main/java/com/nuguna/freview/admin/mapper/RankPointLogMapper.java
+++ b/src/main/java/com/nuguna/freview/admin/mapper/RankPointLogMapper.java
@@ -1,0 +1,11 @@
+package com.nuguna.freview.admin.mapper;
+
+import com.nuguna.freview.admin.vo.PointLogVO;
+import java.util.List;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface RankPointLogMapper {
+
+  List<PointLogVO> getNewLogs(Long lastProcessedSeq);
+}

--- a/src/main/java/com/nuguna/freview/admin/mapper/RankPointLogMapper.java
+++ b/src/main/java/com/nuguna/freview/admin/mapper/RankPointLogMapper.java
@@ -3,9 +3,11 @@ package com.nuguna.freview.admin.mapper;
 import com.nuguna.freview.admin.vo.PointLogVO;
 import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 @Mapper
 public interface RankPointLogMapper {
 
   List<PointLogVO> getNewLogs(Long lastProcessedSeq);
+  int insertLog(@Param("userSeq") Long userSeq, @Param("code") String code);
 }

--- a/src/main/java/com/nuguna/freview/admin/mapper/RankPostprocessingLogMapper.java
+++ b/src/main/java/com/nuguna/freview/admin/mapper/RankPostprocessingLogMapper.java
@@ -1,0 +1,10 @@
+package com.nuguna.freview.admin.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface RankPostprocessingLogMapper {
+
+  Long getLastProcessedSeq();
+  void updateLastProcessedSeq(Long seq);
+}

--- a/src/main/java/com/nuguna/freview/admin/service/ExperienceLogService.java
+++ b/src/main/java/com/nuguna/freview/admin/service/ExperienceLogService.java
@@ -1,10 +1,16 @@
 package com.nuguna.freview.admin.service;
 
-import com.nuguna.freview.admin.dto.ExperienceLogDTO;
+import com.nuguna.freview.admin.dto.DoneExperienceDTO;
+import com.nuguna.freview.admin.dto.DoneExperienceLogDTO;
+import com.nuguna.freview.admin.dto.NoShowExperienceLogDTO;
+import com.nuguna.freview.admin.mapper.DoneExperienceAccumulationMapper;
 import com.nuguna.freview.admin.mapper.ExperienceMapper;
 import com.nuguna.freview.admin.mapper.ExperiencePostProcessingLogMapper;
 import com.nuguna.freview.admin.mapper.NoshowAccumulationMapper;
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -18,37 +24,85 @@ public class ExperienceLogService {
   private final ExperienceMapper experienceMapper;
   private final NoshowAccumulationMapper noshowAccumulationMapper;
   private final ExperiencePostProcessingLogMapper experiencePostProcessingLogMapper;
+  private final DoneExperienceAccumulationMapper doneExperienceAccumulationMapper;
 
   @Autowired
-  public ExperienceLogService(ExperienceMapper experienceMapper, NoshowAccumulationMapper noshowAccumulationMapper,
-      ExperiencePostProcessingLogMapper experiencePostProcessingLogMapper) {
+  public ExperienceLogService(ExperienceMapper experienceMapper,
+      NoshowAccumulationMapper noshowAccumulationMapper,
+      ExperiencePostProcessingLogMapper experiencePostProcessingLogMapper,
+      DoneExperienceAccumulationMapper doneExperienceAccumulationMapper) {
     this.experienceMapper = experienceMapper;
     this.noshowAccumulationMapper = noshowAccumulationMapper;
     this.experiencePostProcessingLogMapper = experiencePostProcessingLogMapper;
+    this.doneExperienceAccumulationMapper = doneExperienceAccumulationMapper;
   }
 
   @Scheduled(cron = "0 0 12,0 * * *")
   @Transactional
   public void processNoShowExperiences() {
-
-    Long lastProcessedSeq = experiencePostProcessingLogMapper.getLastProcessedSeq();
+    String purpose = "NOSHOW_ACCUMULATION";
+    String status = "NOSHOW";
+    Long lastProcessedSeq = experiencePostProcessingLogMapper.getLastProcessedSeq(purpose);
     if (lastProcessedSeq == null) {
       lastProcessedSeq = 0L;
     }
 
-    List<ExperienceLogDTO> experiences = experienceMapper.selectExperiencesToNoShow(lastProcessedSeq);
+    List<NoShowExperienceLogDTO> experiences = experienceMapper.selectNoShowExperiences(
+        lastProcessedSeq, status);
 
     if (!experiences.isEmpty()) {
       experiences.forEach(experience -> {
-        Long userSeqForAccumulation = (experience.getFromPostSeq() == null) ? experience.getToUserSeq() : experience.getFromUserSeq();
+        Long userSeqForAccumulation =
+            (experience.getFromPostSeq() == null) ? experience.getToUserSeq()
+                : experience.getFromUserSeq();
         int rowUpdated = noshowAccumulationMapper.updateNoshowAccumulation(userSeqForAccumulation);
         if (rowUpdated == 0) {
           noshowAccumulationMapper.insertNoshowAccumulation(userSeqForAccumulation);
         }
       });
 
-      Long maxSeq = experiences.stream().mapToLong(ExperienceLogDTO::getSeq).max().getAsLong();
-      experiencePostProcessingLogMapper.updateLastProcessedSeq(maxSeq);
+      Long maxSeq = experiences.stream()
+          .mapToLong(NoShowExperienceLogDTO::getSeq)
+          .max()
+          .getAsLong();
+      experiencePostProcessingLogMapper.updateLastProcessedSeq(purpose, maxSeq);
+    }
+  }
+
+  @Scheduled(cron = "0 0 12,0 * * *")
+  @Transactional
+  public void processDoneExperiences() {
+    String purpose = "DONE_EXPERIENCE_ACCUMULATION";
+    String status = "DONE";
+    Long lastProcessedSeq = experiencePostProcessingLogMapper.getLastProcessedSeq(purpose);
+    if (lastProcessedSeq == null) {
+      lastProcessedSeq = 0L;
+    }
+
+    List<DoneExperienceLogDTO> experiences = experienceMapper.selectDoneExperiences(
+        lastProcessedSeq, status);
+    if (!experiences.isEmpty()) {
+      Map<LocalDate, Long> dailyCounts = experiences.stream()
+          .collect(Collectors.groupingBy(
+              experience -> experience.getVisitDate(),
+              Collectors.counting()
+          ));
+
+      dailyCounts.forEach((date, count) -> {
+        DoneExperienceDTO existingRecord = doneExperienceAccumulationMapper.findByDate(date);
+        if (existingRecord == null) {
+          doneExperienceAccumulationMapper.insert(new DoneExperienceDTO(date, count));
+        } else {
+          existingRecord.setTotalDone(existingRecord.getTotalDone() + count);
+          doneExperienceAccumulationMapper.update(existingRecord);
+        }
+      });
+
+      Long maxSeq = experiences.stream()
+          .mapToLong(DoneExperienceLogDTO::getSeq)
+          .max()
+          .getAsLong();
+      experiencePostProcessingLogMapper.updateLastProcessedSeq(purpose, maxSeq);
     }
   }
 }

--- a/src/main/java/com/nuguna/freview/admin/service/ExperienceLogService.java
+++ b/src/main/java/com/nuguna/freview/admin/service/ExperienceLogService.java
@@ -27,9 +27,9 @@ public class ExperienceLogService {
     this.experiencePostProcessingLogMapper = experiencePostProcessingLogMapper;
   }
 
-  @Scheduled(fixedRate = 1000)
+  @Scheduled(cron = "0 0 12,0 * * *")
   @Transactional
-  public void processExperiences() {
+  public void processNoShowExperiences() {
 
     Long lastProcessedSeq = experiencePostProcessingLogMapper.getLastProcessedSeq();
     if (lastProcessedSeq == null) {

--- a/src/main/java/com/nuguna/freview/admin/service/PointLogService.java
+++ b/src/main/java/com/nuguna/freview/admin/service/PointLogService.java
@@ -1,0 +1,79 @@
+package com.nuguna.freview.admin.service;
+
+import com.nuguna.freview.admin.mapper.RankPointAccumulationMapper;
+import com.nuguna.freview.admin.mapper.RankPointLogMapper;
+import com.nuguna.freview.admin.mapper.RankPostprocessingLogMapper;
+import com.nuguna.freview.admin.vo.PointAccumulationVO;
+import com.nuguna.freview.admin.vo.PointLogVO;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+public class PointLogService {
+
+  private final RankPointLogMapper rankPointLogMapper;
+  private final RankPointAccumulationMapper rankPointAccumulationMapper;
+  private final RankPostprocessingLogMapper rankPostprocessingLogMapper;
+
+  @Autowired
+  public PointLogService(RankPointLogMapper rankPointLogMapper,
+      RankPointAccumulationMapper rankPointAccumulationMapper,
+      RankPostprocessingLogMapper rankPostprocessingLogMapper) {
+    this.rankPointLogMapper = rankPointLogMapper;
+    this.rankPointAccumulationMapper = rankPointAccumulationMapper;
+    this.rankPostprocessingLogMapper = rankPostprocessingLogMapper;
+  }
+
+  @Scheduled(fixedRate = 10000)
+  @Transactional
+  public void processPointLog() {
+    Long lastProcessedSeq = rankPostprocessingLogMapper.getLastProcessedSeq();
+    if (lastProcessedSeq == null) {
+      lastProcessedSeq = 0L;
+    }
+
+    List<PointLogVO> newLogs = rankPointLogMapper.getNewLogs(lastProcessedSeq);
+
+    if (!newLogs.isEmpty()) {
+      Map<Long, Long> pointUpdates = newLogs.stream()
+          .collect(Collectors.groupingBy(PointLogVO::getUserSeq,
+              Collectors.summingLong(log -> calculatePoints(log.getCode()))));
+
+      pointUpdates.forEach((userSeq, points) -> {
+        PointAccumulationVO currentAccumulation = rankPointAccumulationMapper.getByUserSeq(userSeq);
+        if (currentAccumulation == null) {
+          currentAccumulation = new PointAccumulationVO(userSeq, points);
+          rankPointAccumulationMapper.insert(currentAccumulation);
+        } else {
+          currentAccumulation.updateTotalPoint(currentAccumulation.getTotalPoint() + points);
+          rankPointAccumulationMapper.update(currentAccumulation);
+        }
+      });
+
+      Long maxSeq = newLogs.stream().mapToLong(PointLogVO::getSeq).max().getAsLong();
+      rankPostprocessingLogMapper.updateLastProcessedSeq(maxSeq);
+    }
+  }
+
+  private long calculatePoints(String code) {
+    switch (code) {
+      case "POST":
+        return 3;
+      case "UNPOST":
+        return -3;
+      case "ZZIM":
+        return 1;
+      case "UNZZIM":
+        return -1;
+      default:
+        return 0;
+    }
+  }
+}

--- a/src/main/java/com/nuguna/freview/admin/vo/PointAccumulationVO.java
+++ b/src/main/java/com/nuguna/freview/admin/vo/PointAccumulationVO.java
@@ -1,0 +1,16 @@
+package com.nuguna.freview.admin.vo;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PointAccumulationVO {
+
+  private Long userSeq;
+  private Long totalPoint;
+
+  public void updateTotalPoint(Long newTotalPoint) {
+    this.totalPoint = newTotalPoint;
+  }
+}

--- a/src/main/java/com/nuguna/freview/admin/vo/PointLogVO.java
+++ b/src/main/java/com/nuguna/freview/admin/vo/PointLogVO.java
@@ -1,0 +1,13 @@
+package com.nuguna.freview.admin.vo;
+
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Getter
+public class PointLogVO {
+
+  private Long seq;
+  private Long userSeq;
+  private String code;
+  private LocalDateTime createdAt;
+}

--- a/src/main/java/com/nuguna/freview/common/controller/MojipApiController.java
+++ b/src/main/java/com/nuguna/freview/common/controller/MojipApiController.java
@@ -96,7 +96,7 @@ public class MojipApiController {
 
   @RequestMapping(value = "/{deletePostSeq}", method = RequestMethod.DELETE)
   public ResponseEntity<?> deleteMojipPost(@PathVariable Long deletePostSeq) {
-    if (postService.deletePost(deletePostSeq)) {
+    if (mojipService.deletePost(deletePostSeq)) {
       return new ResponseEntity<>(HttpStatus.OK);
     } else {
       return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);

--- a/src/main/java/com/nuguna/freview/common/controller/NoticeApiController.java
+++ b/src/main/java/com/nuguna/freview/common/controller/NoticeApiController.java
@@ -76,7 +76,7 @@ public class NoticeApiController {
 
   @RequestMapping(value = "/{deletePostSeq}", method = RequestMethod.DELETE)
   public ResponseEntity<?> deletePost(@PathVariable Long deletePostSeq) {
-    if (postService.deletePost(deletePostSeq)) {
+    if (noticeService.deletePost(deletePostSeq)) {
       return new ResponseEntity<>(HttpStatus.OK);
     } else {
       return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);

--- a/src/main/java/com/nuguna/freview/common/mapper/PostMapper.java
+++ b/src/main/java/com/nuguna/freview/common/mapper/PostMapper.java
@@ -11,4 +11,5 @@ public interface PostMapper {
   int deletePost(Long postSeq);
   int insertLike(@Param("postSeq") Long postSeq, @Param("userSeq") Long userSeq);
   int deleteLike(@Param("postSeq") Long postSeq, @Param("userSeq") Long userSeq);
+  Long selectWriterSeqByPostSeq(Long postSeq);
 }

--- a/src/main/java/com/nuguna/freview/common/service/MojipService.java
+++ b/src/main/java/com/nuguna/freview/common/service/MojipService.java
@@ -11,4 +11,5 @@ public interface MojipService {
   boolean createMojip(Long userSeq, String title, Date applyStartDate, Date applyEndDate, Date experienceDate, String content);
   boolean updateMojip(Long postSeq, String title, String content);
   boolean applyMojip(Long fromUserSeq, Long toUserSeq, Long fromPostSeq);
+  boolean deletePost(Long postSeq);
 }

--- a/src/main/java/com/nuguna/freview/common/service/NoticeService.java
+++ b/src/main/java/com/nuguna/freview/common/service/NoticeService.java
@@ -8,4 +8,5 @@ public interface NoticeService {
   NoticeDetailResponseDTO getNoticeBySeq(Long postSeq);
   boolean updateNotice(Long postSeq, String title, String content, Timestamp now);
   boolean insertNotice(Long postSeq, String title, String content, Timestamp now);
+  boolean deletePost(Long postSeq);
 }

--- a/src/main/java/com/nuguna/freview/common/service/PostService.java
+++ b/src/main/java/com/nuguna/freview/common/service/PostService.java
@@ -4,7 +4,6 @@ public interface PostService {
 
   boolean isLikedPost(Long userSeq, Long postSeq);
   void addViewCount(Long postSeq);
-  boolean deletePost(Long postSeq);
   boolean addLikeToPost(Long postSeq, Long userSeq);
   boolean cancelLikeToPost(Long postSeq, Long userSeq);
 }

--- a/src/main/java/com/nuguna/freview/common/service/impl/MojipServiceImpl.java
+++ b/src/main/java/com/nuguna/freview/common/service/impl/MojipServiceImpl.java
@@ -1,23 +1,31 @@
 package com.nuguna.freview.common.service.impl;
 
+import com.nuguna.freview.admin.mapper.RankPointLogMapper;
 import com.nuguna.freview.common.dto.response.MojipPostDetailDTO;
 import com.nuguna.freview.common.mapper.MojipMapper;
+import com.nuguna.freview.common.mapper.PostMapper;
 import com.nuguna.freview.common.service.MojipService;
 import java.util.Date;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
 public class MojipServiceImpl implements MojipService {
 
   private final MojipMapper mojipMapper;
+  private final PostMapper postMapper;
+  private final RankPointLogMapper rankPointLogMapper;
 
   @Autowired
-  public MojipServiceImpl(MojipMapper mojipMapper) {
+  public MojipServiceImpl(MojipMapper mojipMapper, PostMapper postMapper, RankPointLogMapper rankPointLogMapper,
+      PostMapper postMapper1, RankPointLogMapper rankPointLogMapper1) {
     this.mojipMapper = mojipMapper;
+    this.postMapper = postMapper1;
+    this.rankPointLogMapper = rankPointLogMapper1;
   }
 
   @Override
@@ -35,10 +43,21 @@ public class MojipServiceImpl implements MojipService {
   }
 
   @Override
+  @Transactional
+  public boolean deletePost(Long postSeq) {
+    int result = postMapper.deletePost(postSeq);
+    Long writerSeq = postMapper.selectWriterSeqByPostSeq(postSeq);
+    int result2 = rankPointLogMapper.insertLog(writerSeq, "UNPOST");
+    return result == 1 && result2 == 1;
+  }
+
+  @Override
+  @Transactional
   public boolean createMojip(Long userSeq, String title, Date applyStartDate,
       Date applyEndDate, Date experienceDate, String content) {
     int result = mojipMapper.insertMojip(userSeq, title, applyStartDate, applyEndDate, experienceDate, content);
-    return result == 1;
+    int result2 = rankPointLogMapper.insertLog(userSeq, "POST");
+    return result == 1 && result2 == 1;
   }
 
   @Override

--- a/src/main/java/com/nuguna/freview/common/service/impl/NoticeServiceImpl.java
+++ b/src/main/java/com/nuguna/freview/common/service/impl/NoticeServiceImpl.java
@@ -2,6 +2,7 @@ package com.nuguna.freview.common.service.impl;
 
 import com.nuguna.freview.common.dto.response.page.NoticeDetailResponseDTO;
 import com.nuguna.freview.common.mapper.NoticeMapper;
+import com.nuguna.freview.common.mapper.PostMapper;
 import com.nuguna.freview.common.service.NoticeService;
 import java.sql.Timestamp;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,15 +12,23 @@ import org.springframework.stereotype.Service;
 public class NoticeServiceImpl implements NoticeService {
 
   private final NoticeMapper noticeMapper;
+  private final PostMapper postMapper;
 
   @Autowired
-  public NoticeServiceImpl(NoticeMapper noticeMapper) {
+  public NoticeServiceImpl(NoticeMapper noticeMapper, PostMapper postMapper) {
     this.noticeMapper = noticeMapper;
+    this.postMapper = postMapper;
   }
 
   @Override
   public NoticeDetailResponseDTO getNoticeBySeq(Long postSeq) {
     return noticeMapper.selectNotice(postSeq);
+  }
+
+  @Override
+  public boolean deletePost(Long postSeq) {
+    int result = postMapper.deletePost(postSeq);
+    return result == 1;
   }
 
   @Override

--- a/src/main/java/com/nuguna/freview/common/service/impl/PostServiceImpl.java
+++ b/src/main/java/com/nuguna/freview/common/service/impl/PostServiceImpl.java
@@ -31,12 +31,6 @@ public class PostServiceImpl implements PostService {
   }
 
   @Override
-  public boolean deletePost(Long postSeq) {
-    int result = postMapper.deletePost(postSeq);
-    return result == 1;
-  }
-
-  @Override
   @Transactional
   public boolean addLikeToPost(Long postSeq, Long userSeq) {
     int result = postMapper.insertLike(postSeq, userSeq);

--- a/src/main/resources/mappers/admin/done-experience-accumulation-map.xml
+++ b/src/main/resources/mappers/admin/done-experience-accumulation-map.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.nuguna.freview.admin.mapper.DoneExperienceAccumulationMapper">
+
+  <resultMap id="doneExperienceResultMap" type="com.nuguna.freview.admin.dto.DoneExperienceDTO">
+    <result property="date" column="created_at" javaType="java.time.LocalDate"/>
+    <result property="totalCount" column="total_count"/>
+  </resultMap>
+
+  <select id="findByDate" resultMap="doneExperienceResultMap">
+    SELECT date, total_count
+    FROM done_experience_accumulation
+    WHERE date = #{date}
+  </select>
+
+  <insert id="insert">
+    INSERT INTO done_experience_accumulation (date, total_count)
+    VALUES (#{date}, #{totalDone})
+  </insert>
+
+  <update id="update">
+    UPDATE done_experience_accumulation
+    SET total_count = #{totalDone}
+    WHERE date = #{date}
+  </update>
+
+</mapper>

--- a/src/main/resources/mappers/admin/experience-map.xml
+++ b/src/main/resources/mappers/admin/experience-map.xml
@@ -5,8 +5,8 @@
 <mapper namespace="com.nuguna.freview.admin.mapper.ExperienceMapper">
 
   <!-- resultMap -->
-  <!-- Experience resultMap -->
-  <resultMap id="experienceResultMap" type="com.nuguna.freview.admin.dto.ExperienceLogDTO">
+  <!-- noshow resultMap -->
+  <resultMap id="noShowExperienceResultMap" type="com.nuguna.freview.admin.dto.NoShowExperienceLogDTO">
     <id property="seq" column="seq"/>
     <result property="fromUserSeq" column="from_user_seq"/>
     <result property="toUserSeq" column="to_user_seq"/>
@@ -14,11 +14,25 @@
     <result property="status" column="status"/>
   </resultMap>
 
+  <resultMap id="DoneExperienceResultMap" type="com.nuguna.freview.admin.dto.DoneExperienceLogDTO">
+    <id property="seq" column="seq"/>
+    <result property="visitDate" column="visit_date" javaType="java.time.LocalDate" jdbcType="TIMESTAMP"/>
+  </resultMap>
+
   <!-- 'NOSHOW'인 experience 데이터 조회 -->
-  <select id="selectExperiencesToNoShow" parameterType="long" resultMap="experienceResultMap">
+  <select id="selectNoShowExperiences" parameterType="map" resultMap="noShowExperienceResultMap">
     SELECT seq, from_user_seq, to_user_seq, from_post_seq, status
     FROM experience
-    WHERE status = 'NOSHOW' AND seq > #{lastProcessedSeq}
+    WHERE status = #{status} AND seq > #{lastProcessedSeq}
+    ORDER BY seq ASC
+    LIMIT 100
+  </select>
+
+  <!-- 'DONE'인 experience 데이터 조회 -->
+  <select id="selectDoneExperiences" parameterType="map" resultMap="DoneExperienceResultMap">
+    SELECT seq, visit_date
+    FROM experience
+    WHERE status = #{status} AND seq > #{lastProcessedSeq}
     ORDER BY seq ASC
     LIMIT 100
   </select>

--- a/src/main/resources/mappers/admin/experience-postprocessing-log-map.xml
+++ b/src/main/resources/mappers/admin/experience-postprocessing-log-map.xml
@@ -5,16 +5,16 @@
 <mapper namespace="com.nuguna.freview.admin.mapper.ExperiencePostProcessingLogMapper">
 
   <!-- 마지막으로 처리한 seq 로깅 -->
-  <insert id="updateLastProcessedSeq" parameterType="long">
+  <insert id="updateLastProcessedSeq" parameterType="map">
     insert into experience_postprocessing_log (last_processed_seq, purpose)
-    values (#{seq}, 'NOSHOW_ACCUMULATION')
+    values (#{seq}, #{purpose})
   </insert>
 
   <!-- 최근 처리된 작업 번호 가져오기 -->
-  <select id="getLastProcessedSeq" resultType="long">
+  <select id="getLastProcessedSeq" parameterType="map" resultType="long">
     SELECT last_processed_seq
     FROM experience_postprocessing_log
-    WHERE purpose = 'NOSHOW_ACCUMULATION'
+    WHERE purpose = #{purpose}
     order by seq DESC
     limit 1
   </select>

--- a/src/main/resources/mappers/admin/rank-point-accumulation-map.xml
+++ b/src/main/resources/mappers/admin/rank-point-accumulation-map.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.nuguna.freview.admin.mapper.RankPointAccumulationMapper">
+
+  <resultMap id="pointLogResultMap" type="com.nuguna.freview.admin.vo.PointAccumulationVO">
+    <id property="userSeq" column="user_seq"/>
+    <result property="totalPoint" column="total_point"/>
+  </resultMap>
+
+  <select id="getByUserSeq" resultMap="pointLogResultMap">
+    SELECT user_seq, total_point
+    FROM point_accumulation
+    WHERE user_seq = #{userSeq}
+  </select>
+
+  <insert id="insert">
+    INSERT INTO point_accumulation (user_seq, total_point)
+    VALUES (#{userSeq}, #{totalPoint})
+  </insert>
+
+  <update id="update">
+    UPDATE point_accumulation
+    SET total_point = #{totalPoint}
+    WHERE user_seq = #{userSeq}
+  </update>
+
+</mapper>

--- a/src/main/resources/mappers/admin/rank-point-log-map.xml
+++ b/src/main/resources/mappers/admin/rank-point-log-map.xml
@@ -11,6 +11,12 @@
     <result property="createdAt" column="created_at" javaType="java.time.LocalDateTime" jdbcType="TIMESTAMP"/>
   </resultMap>
 
+  <!-- SQL 쿼리문 -->
+  <insert id="insertPointLog" parameterType="map">
+    insert into point_log (user_seq, code)
+    values (#{userSeq}, #{code})
+  </insert>
+
   <select id="getNewLogs" resultMap="pointLogResultMap">
     SELECT seq, user_seq, code, created_at
     FROM point_log

--- a/src/main/resources/mappers/admin/rank-point-log-map.xml
+++ b/src/main/resources/mappers/admin/rank-point-log-map.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.nuguna.freview.admin.mapper.RankPointLogMapper">
+
+  <resultMap id="pointLogResultMap" type="com.nuguna.freview.admin.vo.PointLogVO">
+    <id property="seq" column="seq"/>
+    <result property="userSeq" column="user_seq"/>
+    <result property="code" column="code"/>
+    <result property="createdAt" column="created_at" javaType="java.time.LocalDateTime" jdbcType="TIMESTAMP"/>
+  </resultMap>
+
+  <select id="getNewLogs" resultMap="pointLogResultMap">
+    SELECT seq, user_seq, code, created_at
+    FROM point_log
+    WHERE seq &gt; #{lastProcessedSeq}
+    limit 100;
+  </select>
+
+</mapper>

--- a/src/main/resources/mappers/admin/rank-point-postprocessing-log-map.xml
+++ b/src/main/resources/mappers/admin/rank-point-postprocessing-log-map.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.nuguna.freview.admin.mapper.RankPostprocessingLogMapper">
+
+<select id="getLastProcessedSeq" resultType="long">
+  SELECT last_processed_point_seq
+  FROM point_postprocessing_log
+  ORDER BY seq DESC
+  LIMIT 1
+</select>
+
+  <insert id="updateLastProcessedSeq">
+    INSERT INTO freview2.point_postprocessing_log (last_processed_point_seq)
+    VALUES (#{seq})
+  </insert>
+</mapper>

--- a/src/main/resources/mappers/common/post-map.xml
+++ b/src/main/resources/mappers/common/post-map.xml
@@ -40,4 +40,9 @@
     where user_seq = #{userSeq} and post_seq = #{postSeq}
   </delete>
 
+  <!-- 특정 게시글 작성자 조회 -->
+  <select id="selectWriterSeqByPostSeq" parameterType="Long">
+    select seq from post where seq = #{postSeq}
+  </select>
+
 </mapper>


### PR DESCRIPTION
### [목적]
- 유저의 특정 액션에 따라 포인트가 +, - 누계되는 시스템
- 체험단/사장님 추천페이지에서 top랭킹의 유저 리스트를 보여줄 수 있음

**[ 특정 액션 ]**
- 체험단이 리뷰를 작성할 때 > 해당 리뷰작성자 +3점
- 관리자가 리뷰를 삭제할 때 > 해당 리뷰작성자 -3점
- 사장님이 모집글을 작성 / 삭제할 때 > 작성자 +3점 / -3점
- 모든 유저가 찜을 받을 때 / 취소 당했을 때에 따라 > 받은 자 +1점 / -1점

### [로직]
- point_log 의 code 에 따라 점수를 다르게 부과, 해당 작업은 스케줄러를 통해 10초마다 작업된다