### PR TITLE
[Feat-security-oauth-login] 구글 유저 인증 진행(완성)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ mvnw.cmd
 !**/src/test/**/target/
 
 ### IntelliJ IDEA ###
+googleLoginInfo.properties
+jwt.properties
+sendEmail.properties
 .idea
 .idea/modules.xml
 .idea/jarRepositories.xml

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,11 @@
       <artifactId>spring-security-web</artifactId>
       <version>${org.springframework-version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.security.oauth</groupId>
+      <artifactId>spring-security-oauth2</artifactId>
+      <version>2.0.7.RELEASE</version>
+    </dependency>
 
     <!-- jwt token-->
     <dependency>

--- a/src/main/java/com/nuguna/freview/OAuth/controller/OAuthApiController.java
+++ b/src/main/java/com/nuguna/freview/OAuth/controller/OAuthApiController.java
@@ -1,0 +1,37 @@
+package com.nuguna.freview.OAuth.controller;
+
+import com.nuguna.freview.OAuth.dto.request.GoogleUserRegistRequestDTO;
+import com.nuguna.freview.common.service.RegisterService;
+import javax.validation.Valid;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+public class OAuthApiController {
+
+  private final RegisterService registerService;
+
+  @Autowired
+  public OAuthApiController(RegisterService registerService) {
+    this.registerService = registerService;
+  }
+
+  @RequestMapping(value = "/api/google/register", method = RequestMethod.POST)
+  public void register(@Valid @RequestBody GoogleUserRegistRequestDTO googleUserRegistRequestDTO){
+
+    log.info("구글유저 회원가입");
+    if(googleUserRegistRequestDTO.getCode().equals("CUSTOMER")){
+      registerService.oAuthCustomerRegist(googleUserRegistRequestDTO);
+    }else if(googleUserRegistRequestDTO.getCode().equals("STORE")){
+      registerService.oAuthStoreRegist(googleUserRegistRequestDTO);
+    }
+
+  }
+
+}

--- a/src/main/java/com/nuguna/freview/OAuth/controller/OAuthController.java
+++ b/src/main/java/com/nuguna/freview/OAuth/controller/OAuthController.java
@@ -37,18 +37,18 @@ public class OAuthController {
     boolean userCheck = oauthUserService.checkUser(userInfo.getEmail());
     if(!userCheck){
       request.getSession().setAttribute("OAuthUser", userInfo);
-      return "redirect: /oauth-register-page";
+      return "redirect: /google-register-page";
     }else{
     return "/login-page";}
   }
 
-  @RequestMapping(value="/oauth-register-page", method = RequestMethod.GET)
+  @RequestMapping(value="/google-register-page", method = RequestMethod.GET)
   public String goToRegisterPage(Model model, HttpServletRequest httpRequest) {
 
     GoogleUserInfoDTO userInfo = (GoogleUserInfoDTO)httpRequest.getSession().getAttribute("OAuthUser");
     System.out.println(userInfo);
     model.addAttribute("userInfo", userInfo);
-    return "/common-oauth-register";
+    return "/common-google-register";
   }
 
 }

--- a/src/main/java/com/nuguna/freview/OAuth/controller/OAuthController.java
+++ b/src/main/java/com/nuguna/freview/OAuth/controller/OAuthController.java
@@ -1,0 +1,54 @@
+package com.nuguna.freview.OAuth.controller;
+
+import com.nuguna.freview.OAuth.dto.response.GoogleUserInfoDTO;
+import com.nuguna.freview.OAuth.service.OAuthService;
+import com.nuguna.freview.OAuth.service.OAuthUserService;
+import java.util.Map;
+import javax.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+@Slf4j
+@Controller
+public class OAuthController {
+
+  private final OAuthService oauthService;
+  private final OAuthUserService oauthUserService;
+
+  @Autowired
+  public OAuthController(OAuthService oauthService, OAuthUserService oauthUserService) {
+    this.oauthService = oauthService;
+    this.oauthUserService = oauthUserService;
+  }
+
+  @RequestMapping(value="/oauth2callback", method = RequestMethod.GET)
+  public String ctlCallback(Model model, RedirectAttributes redirectAttributes,
+      @RequestParam("code") String code, HttpServletRequest request) {
+
+    String accessToken = oauthService.getRequestAccessToken(code);
+    GoogleUserInfoDTO userInfo = oauthService.getRequestUserInfo(accessToken);
+    boolean userCheck = oauthUserService.checkUser(userInfo.getEmail());
+    if(!userCheck){
+      request.getSession().setAttribute("OAuthUser", userInfo);
+      return "redirect: /oauth-register-page";
+    }else{
+    return "/login-page";}
+  }
+
+  @RequestMapping(value="/oauth-register-page", method = RequestMethod.GET)
+  public String goToRegisterPage(Model model, HttpServletRequest httpRequest) {
+
+    GoogleUserInfoDTO userInfo = (GoogleUserInfoDTO)httpRequest.getSession().getAttribute("OAuthUser");
+    System.out.println(userInfo);
+    model.addAttribute("userInfo", userInfo);
+    return "/common-oauth-register";
+  }
+
+}

--- a/src/main/java/com/nuguna/freview/OAuth/controller/OAuthController.java
+++ b/src/main/java/com/nuguna/freview/OAuth/controller/OAuthController.java
@@ -3,10 +3,22 @@ package com.nuguna.freview.OAuth.controller;
 import com.nuguna.freview.OAuth.dto.response.GoogleUserInfoDTO;
 import com.nuguna.freview.OAuth.service.OAuthService;
 import com.nuguna.freview.OAuth.service.OAuthUserService;
+import com.nuguna.freview.security.JwtUtil;
+import com.nuguna.freview.security.login.CustomUserDetail;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Iterator;
 import java.util.Map;
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -21,11 +33,15 @@ public class OAuthController {
 
   private final OAuthService oauthService;
   private final OAuthUserService oauthUserService;
+  final UserDetailsService userDetailsService;
+  final JwtUtil jwtUtil;
 
   @Autowired
-  public OAuthController(OAuthService oauthService, OAuthUserService oauthUserService) {
+  public OAuthController(OAuthService oauthService, OAuthUserService oauthUserService, UserDetailsService userDetailsService, JwtUtil jwtUtil) {
     this.oauthService = oauthService;
     this.oauthUserService = oauthUserService;
+    this.userDetailsService = userDetailsService;
+    this.jwtUtil = jwtUtil;
   }
 
   @RequestMapping(value="/oauth2callback", method = RequestMethod.GET)
@@ -35,11 +51,11 @@ public class OAuthController {
     String accessToken = oauthService.getRequestAccessToken(code);
     GoogleUserInfoDTO userInfo = oauthService.getRequestUserInfo(accessToken);
     boolean userCheck = oauthUserService.checkUser(userInfo.getEmail());
+    request.getSession().setAttribute("OAuthUser", userInfo);
     if(!userCheck){
-      request.getSession().setAttribute("OAuthUser", userInfo);
       return "redirect: /google-register-page";
     }else{
-    return "/login-page";}
+    return "redirect: /google-login";}
   }
 
   @RequestMapping(value="/google-register-page", method = RequestMethod.GET)
@@ -49,6 +65,40 @@ public class OAuthController {
     System.out.println(userInfo);
     model.addAttribute("userInfo", userInfo);
     return "/common-google-register";
+  }
+
+  @RequestMapping(value="/google-login", method = RequestMethod.GET)
+  public String googleLogin(Model model, HttpServletRequest httpRequest, HttpServletResponse httpServletResponse) {
+    GoogleUserInfoDTO userInfo = (GoogleUserInfoDTO) httpRequest.getSession().getAttribute("OAuthUser");
+    String username = userInfo.getEmail();
+   CustomUserDetail customUserDetails = (CustomUserDetail)userDetailsService.loadUserByUsername(username);
+
+    Long userSeq = customUserDetails.getUserVO().getSeq();
+    String userEmail = customUserDetails.getUsername();
+    Collection<GrantedAuthority> authorities = customUserDetails.getAuthorities();
+    Iterator<GrantedAuthority> iterator = authorities.iterator();
+    GrantedAuthority grantedAuthority = iterator.next();
+    String role = grantedAuthority.getAuthority();
+
+    //jwt 생성
+    String accessToken = jwtUtil.createToken(userSeq, userEmail, role,1000L * 60 * 60);
+    String refreshToken = jwtUtil.createToken(userSeq, userEmail, role,1000L * 60 * 180);
+
+    // 리프레시 토큰 쿠키에 저장
+    Cookie refreshCookie = new Cookie("refresh", refreshToken);
+    refreshCookie.setPath("/");
+    refreshCookie.setMaxAge(60*180);
+    refreshCookie.setSecure(true);
+
+    httpServletResponse.setHeader("Authorization", "Bearer " + accessToken);
+    httpServletResponse.addCookie(refreshCookie);
+    if(role.equals("ROLE_ADMIN")) {
+      return "redirect: /admin/manage/store";
+    }else if(role.equals("ROLE_CUSTOMER")) {
+      return "redirect: /customer/main-page";
+    } else{
+      return "redirect: /user/main-page";
+    }
   }
 
 }

--- a/src/main/java/com/nuguna/freview/OAuth/dto/request/GoogleUserRegistRequestDTO.java
+++ b/src/main/java/com/nuguna/freview/OAuth/dto/request/GoogleUserRegistRequestDTO.java
@@ -1,0 +1,18 @@
+package com.nuguna.freview.OAuth.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GoogleUserRegistRequestDTO {
+  private String email;
+  private String subEmail;
+  private String nickname;
+  private String ageGroup;
+  private String code;
+  private String storeLocation;
+  private String businessNumber;
+}

--- a/src/main/java/com/nuguna/freview/OAuth/dto/response/GoogleUserInfoDTO.java
+++ b/src/main/java/com/nuguna/freview/OAuth/dto/response/GoogleUserInfoDTO.java
@@ -1,0 +1,14 @@
+package com.nuguna.freview.OAuth.dto.response;
+
+import lombok.Data;
+
+@Data
+public class GoogleUserInfoDTO {
+     private String email;
+     private String given_name;
+     private String verified_email;
+     private String name;
+     private String id;
+     private String picture;
+     private String family_name;
+}

--- a/src/main/java/com/nuguna/freview/OAuth/service/OAuthService.java
+++ b/src/main/java/com/nuguna/freview/OAuth/service/OAuthService.java
@@ -1,0 +1,14 @@
+package com.nuguna.freview.OAuth.service;
+
+import com.nuguna.freview.OAuth.dto.response.GoogleUserInfoDTO;
+import java.util.Map;
+
+public interface OAuthService {
+
+  String getLoginFormUrl();
+
+  String getRequestAccessToken(String code);
+
+  GoogleUserInfoDTO getRequestUserInfo(String accessToken);
+
+}

--- a/src/main/java/com/nuguna/freview/OAuth/service/OAuthUserService.java
+++ b/src/main/java/com/nuguna/freview/OAuth/service/OAuthUserService.java
@@ -1,0 +1,6 @@
+package com.nuguna.freview.OAuth.service;
+
+public interface OAuthUserService {
+
+  boolean checkUser(String email);
+}

--- a/src/main/java/com/nuguna/freview/OAuth/service/impl/OAuthServiceImpl.java
+++ b/src/main/java/com/nuguna/freview/OAuth/service/impl/OAuthServiceImpl.java
@@ -1,0 +1,62 @@
+package com.nuguna.freview.OAuth.service.impl;
+
+import com.nuguna.freview.OAuth.dto.response.GoogleUserInfoDTO;
+import com.nuguna.freview.OAuth.service.OAuthService;
+import com.nuguna.freview.common.mapper.RegisterMapper;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.codehaus.jackson.type.TypeReference;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.client.RestTemplate;
+
+public class OAuthServiceImpl implements OAuthService {
+
+  private final String clientId;
+  private final String clientSecret;
+  private final String redirectUri;
+  private final String tokenEndpoint;
+  private final String userInfoEndpoint;
+
+  public OAuthServiceImpl(String clientId, String clientSecret, String redirectUri, String tokenEndpoint, String userInfoEndpoint) {
+    this.clientId = clientId;
+    this.clientSecret = clientSecret;
+    this.redirectUri = redirectUri;
+    this.tokenEndpoint = tokenEndpoint;
+    this.userInfoEndpoint = userInfoEndpoint;
+  }
+
+  @Override
+  public String getLoginFormUrl() {
+    String scope = "https://www.googleapis.com/auth/userinfo.profile";
+    String reqUrl = "https://accounts.google.com/o/oauth2/v2/auth?client_id=" + clientId
+        + "&redirect_uri="+redirectUri+"&response_type=code&scope=email%20profile%20openid&access_type=offline";
+    return reqUrl;
+  }
+
+  @Override
+  public String getRequestAccessToken(String code) {
+
+    RestTemplate restTemplate = new RestTemplate();
+    Map<String, String> params = new HashMap<>();
+
+    params.put("code"			, code);
+    params.put("client_id"		, clientId);
+    params.put("client_secret"	, clientSecret);
+    params.put("redirect_uri"	, redirectUri);
+    params.put("grant_type"		, "authorization_code");
+
+    Map<String, String> response = restTemplate.postForObject(tokenEndpoint, params, Map.class);
+    return response.get("access_token");
+  }
+
+  @Override
+  public GoogleUserInfoDTO getRequestUserInfo(String accessToken){
+    RestTemplate restTemplate = new RestTemplate();
+    String url = userInfoEndpoint + "?access_token=" + accessToken;
+    GoogleUserInfoDTO userInfo = restTemplate.getForObject(url, GoogleUserInfoDTO.class);
+    return userInfo;
+  }
+
+}

--- a/src/main/java/com/nuguna/freview/OAuth/service/impl/OAuthUserServiceImpl.java
+++ b/src/main/java/com/nuguna/freview/OAuth/service/impl/OAuthUserServiceImpl.java
@@ -1,0 +1,22 @@
+package com.nuguna.freview.OAuth.service.impl;
+
+import com.nuguna.freview.OAuth.service.OAuthUserService;
+import com.nuguna.freview.common.mapper.RegisterMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class OAuthUserServiceImpl implements OAuthUserService {
+
+  private final RegisterMapper registerMapper;
+
+  @Autowired
+  public OAuthUserServiceImpl(RegisterMapper registerMapper) {
+    this.registerMapper = registerMapper;
+  }
+
+  @Override
+  public boolean checkUser(String email) {
+    return registerMapper.getDuplicatedEmail(email);
+  }
+}

--- a/src/main/java/com/nuguna/freview/common/controller/AuthController.java
+++ b/src/main/java/com/nuguna/freview/common/controller/AuthController.java
@@ -1,7 +1,13 @@
 package com.nuguna.freview.common.controller;
 
+import com.nuguna.freview.OAuth.dto.response.GoogleUserInfoDTO;
+import com.nuguna.freview.OAuth.service.OAuthService;
+import com.nuguna.freview.OAuth.service.impl.OAuthServiceImpl;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 
@@ -9,9 +15,18 @@ import org.springframework.web.bind.annotation.RequestMethod;
 @Controller
 public class AuthController {
 
+  final OAuthService oauthService;
+
+  @Autowired
+  public AuthController(OAuthService oauthService) {
+    this.oauthService = oauthService;
+  }
+
   @RequestMapping(value = "/login-page", method = RequestMethod.GET)
-  public String goToLogin() {
+  public String goToLogin(Model model) {
     log.info("로그인 페이지로 이동");
+    String googleLoginUrl = oauthService.getLoginFormUrl();
+    model.addAttribute("googleLoginUrl", googleLoginUrl);
     return "common-login";
   }
 
@@ -26,5 +41,7 @@ public class AuthController {
     log.info("로그인 에러 페이지로 이동");
     return "common-login-fail";
   }
+
+
 
 }

--- a/src/main/java/com/nuguna/freview/common/mapper/RegisterMapper.java
+++ b/src/main/java/com/nuguna/freview/common/mapper/RegisterMapper.java
@@ -10,4 +10,6 @@ public interface RegisterMapper {
   void insertCustomerInfo(UserVO uvo);
   boolean getCheckBusinessNumber(String businessNumber);
   void insertStoreInfo(UserVO uvo);
+  void insertOAuthCustomerInfo(UserVO uvo);
+  void insertOAuthStoreInfo(UserVO uvo);
 }

--- a/src/main/java/com/nuguna/freview/common/service/RegisterService.java
+++ b/src/main/java/com/nuguna/freview/common/service/RegisterService.java
@@ -1,5 +1,6 @@
 package com.nuguna.freview.common.service;
 
+import com.nuguna.freview.OAuth.dto.request.GoogleUserRegistRequestDTO;
 import com.nuguna.freview.common.dto.request.RegisterCheckBusinessNumberDTO;
 import com.nuguna.freview.common.dto.request.RegisterCheckIdRequestDTO;
 import com.nuguna.freview.common.dto.request.RegisterCheckNickNameRequestDTO;
@@ -11,4 +12,6 @@ public interface RegisterService {
   void cutomerRegist(RegisterRequestDTO registerRequestDTO);
   boolean checkBusinessNumber(RegisterCheckBusinessNumberDTO registerCheckBusinessNumberDTO);
   void storeRegist(RegisterRequestDTO registerRequestDTO);
+  void oAuthCustomerRegist(GoogleUserRegistRequestDTO googleUserRegistRequestDTO);
+  void oAuthStoreRegist(GoogleUserRegistRequestDTO googleUserRegistRequestDTO);
 }

--- a/src/main/java/com/nuguna/freview/common/service/impl/RegisterServiceImpl.java
+++ b/src/main/java/com/nuguna/freview/common/service/impl/RegisterServiceImpl.java
@@ -1,5 +1,6 @@
 package com.nuguna.freview.common.service.impl;
 
+import com.nuguna.freview.OAuth.dto.request.GoogleUserRegistRequestDTO;
 import com.nuguna.freview.common.dto.request.RegisterCheckBusinessNumberDTO;
 import com.nuguna.freview.common.dto.request.RegisterCheckIdRequestDTO;
 import com.nuguna.freview.common.dto.request.RegisterCheckNickNameRequestDTO;
@@ -83,5 +84,32 @@ public class RegisterServiceImpl implements RegisterService {
         .loginType("FORM")
         .isWithDrawn(false).build();
     registerMapper.insertStoreInfo(uvo);
+  }
+
+  @Override
+  public void oAuthCustomerRegist(GoogleUserRegistRequestDTO googleUserRegistRequestDTO) {
+    UserVO uvo = UserVO.builder()
+        .email(googleUserRegistRequestDTO.getEmail())
+        .subEmail(googleUserRegistRequestDTO.getSubEmail())
+        .nickname(googleUserRegistRequestDTO.getNickname())
+        .ageGroup(googleUserRegistRequestDTO.getAgeGroup())
+        .code(googleUserRegistRequestDTO.getCode())
+        .loginType("GOOGLE")
+        .isWithDrawn(false).build();
+    registerMapper.insertOAuthCustomerInfo(uvo);
+  }
+
+  @Override
+  public void oAuthStoreRegist(GoogleUserRegistRequestDTO googleUserRegistRequestDTO) {
+    UserVO uvo = UserVO.builder()
+        .email(googleUserRegistRequestDTO.getEmail())
+        .subEmail(googleUserRegistRequestDTO.getSubEmail())
+        .businessNumber(googleUserRegistRequestDTO.getBusinessNumber())
+        .storeLocation(googleUserRegistRequestDTO.getStoreLocation())
+        .code(googleUserRegistRequestDTO.getCode())
+        .ageGroup(googleUserRegistRequestDTO.getAgeGroup())
+        .loginType("GOOGLE")
+        .isWithDrawn(false).build();
+    registerMapper.insertOAuthStoreInfo(uvo);
   }
 }

--- a/src/main/java/com/nuguna/freview/security/login/CustomUserDetailsService.java
+++ b/src/main/java/com/nuguna/freview/security/login/CustomUserDetailsService.java
@@ -1,5 +1,6 @@
 package com.nuguna.freview.security.login;
 
+import com.nuguna.freview.common.vo.user.UserCode;
 import com.nuguna.freview.common.vo.user.UserVO;
 import com.nuguna.freview.security.login.service.LoginService;
 import java.util.ArrayList;
@@ -32,13 +33,23 @@ public class CustomUserDetailsService implements UserDetailsService {
       throw new UsernameNotFoundException("email");
     }
     List<GrantedAuthority> authorities = new ArrayList<GrantedAuthority>();
-    if(userVO.getCode().equals("ADMIN")){
+//    if(userVO.getCode().equals("ADMIN")){
+//      authorities.add(new SimpleGrantedAuthority("ROLE_ADMIN"));
+//    }else if(userVO.getCode().equals("CUSTOMER")){
+//      authorities.add(new SimpleGrantedAuthority("ROLE_CUSTOMER"));
+//    }else if(userVO.getCode().equals("STORE")){
+//      authorities.add(new SimpleGrantedAuthority("ROLE_STORE"));
+//    }
+
+    UserCode userCode = UserCode.from(userVO.getCode());
+    if(userCode.isAdmin()){
       authorities.add(new SimpleGrantedAuthority("ROLE_ADMIN"));
-    }else if(userVO.getCode().equals("CUSTOMER")){
+    } else if(userCode.isCustomer()){
       authorities.add(new SimpleGrantedAuthority("ROLE_CUSTOMER"));
-    }else if(userVO.getCode().equals("STORE")){
+    } else if(userCode.isStore()){
       authorities.add(new SimpleGrantedAuthority("ROLE_STORE"));
     }
+
     return new CustomUserDetail(email, userVO.getPassword(), authorities,userVO);
   }
 

--- a/src/main/resources/mappers/auth/register/register-map.xml
+++ b/src/main/resources/mappers/auth/register/register-map.xml
@@ -44,5 +44,20 @@
     INSERT INTO user (business_number,code,email,password,nickname,sub_email,login_type,is_withdrawn,age_Group,store_location)
     values(#{businessNumber},#{code},#{email},#{password},#{nickname},#{subEmail},#{loginType},#{isWithDrawn},#{ageGroup},#{storeLocation})
   </insert>
+
+  <insert id="insertOAuthCustomerInfo" parameterType="com.nuguna.freview.common.vo.user.UserVO">
+    INSERT INTO user (code,email,nickname,sub_email,login_type,is_withdrawn,age_group)
+    VALUES (#{code},#{email},#{nickname},#{subEmail},#{loginType},#{isWithDrawn},#{ageGroup})
+  </insert>
+
+
+  <insert id="insertOAuthStoreInfo" parameterType="com.nuguna.freview.common.vo.user.UserVO">
+    <selectKey resultType="String" keyProperty="nickname" order="BEFORE">
+      select store_name from national_store_business_information where business_number = #{businessNumber}
+    </selectKey>
+    INSERT INTO user (business_number,code,email,nickname,sub_email,login_type,is_withdrawn,age_Group,store_location)
+    values(#{businessNumber},#{code},#{email},#{nickname},#{subEmail},#{loginType},#{isWithDrawn},#{ageGroup},#{storeLocation})
+  </insert>
+
 </mapper>
 

--- a/src/main/webapp/WEB-INF/spring/root-context.xml
+++ b/src/main/webapp/WEB-INF/spring/root-context.xml
@@ -10,7 +10,7 @@
 ">
 	<context:component-scan base-package="com.nuguna.freview" />
 
-	<context:property-placeholder location="classpath:maria.properties,classpath:sendEmail.properties"/>
+	<context:property-placeholder location="classpath:maria.properties,classpath:sendEmail.properties, classpath:googleLoginInfo.properties"/>
 	<!-- ################################################################################  -->
 	<!-- =============================== datasource : 프로퍼티 파일을 사용한 형태 -->
 
@@ -93,6 +93,14 @@
 		<constructor-arg index="2" value="${gmail-smtphost}"/>
 		<constructor-arg index="3" value="${gmail-usermail}"/>
 		<constructor-arg index="4" value="${gmail-password}"/>
+	</bean>
+
+	<bean id="oauthServiceImpl" class="com.nuguna.freview.OAuth.service.impl.OAuthServiceImpl">
+		<constructor-arg index="0" value="${clientId}"/>
+		<constructor-arg index="1" value="${clientSecret}"/>
+		<constructor-arg index="2" value="${redirectUrl}"/>
+		<constructor-arg index="3" value="${tokenEndpoint}"/>
+		<constructor-arg index="4" value="${userInfoEndpoint}"/>
 	</bean>
 
 </beans>

--- a/src/main/webapp/WEB-INF/spring/security-context.xml
+++ b/src/main/webapp/WEB-INF/spring/security-context.xml
@@ -26,7 +26,7 @@
 		<intercept-url pattern="/member/logout" 	access="permitAll" />
 		<intercept-url pattern="/member/map" 		access="hasRole('ROLE_ADMIN')" />
 		<intercept-url pattern="/**" 				access="permitAll" />
-
+		<intercept-url pattern="/oauth/**" access="permitAll"/>
 		<form-login
 			login-processing-url="/login"
 			username-parameter="id"
@@ -36,6 +36,7 @@
 			authentication-success-handler-ref="authSuccessHandler"
 			authentication-failure-handler-ref="authFailureHandler"
 		/>
+
 	</http>
 
 
@@ -47,6 +48,7 @@
 	<beans:bean id="authSuccessHandler" class="com.nuguna.freview.security.login.SuccessHandler">
 		<beans:constructor-arg name="jwtUtil" ref="jwtUtil"/>
 	</beans:bean>
+	<beans:bean id="passwordEncoder" class="org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder"/>
 	<beans:bean id="authFailureHandler"	class="com.nuguna.freview.security.login.FailureHandler"/>
 	<beans:bean id="customAuthenticationProvider" class="com.nuguna.freview.security.login.CustomAuthenticationProvider"/>
 	<beans:bean id="customUserDetailsService" class="com.nuguna.freview.security.login.CustomUserDetailsService"/>

--- a/src/main/webapp/assets/js/hr.js
+++ b/src/main/webapp/assets/js/hr.js
@@ -639,6 +639,100 @@ $("#Input_pw").change(function(){ // COMM_register 비밀번호 형식 확인
 
   })
 
+  $("#COMM_register_btn_oauth_Boss_regist").click(function(){             //common-oauth-register Store 회원가입
+
+    let inputSubEmail = $("#COMM_register_input_Boss_email").val();
+    let inputEmail = $("#Boss_Input_ID").val();
+    let inputBusinessNumber = $("#COMM_register_input_Boss_buisnessInfo").val();
+    let inputBusinessAddress =  $("#COMM_register_input_Boss_buisnessaddress").val();
+    let inputAgeGroup = $("#Input_Boss_AgeGroup").val();
+
+    let email_subEmail_check = false;
+    if(inputEmail!=inputSubEmail)
+      email_subEmail_check = true;
+
+    if(COMM_register_emailNumberCheck&&COMM_register_acceptTerms&&COMM_register_businessInfo&&COMM_register_buisnessloc&&email_subEmail_check){
+
+      $.ajax({
+        method: "post",
+        url : "/api/google/register",
+        contentType: "application/json",
+        data: JSON.stringify({
+          email : inputEmail,
+          subEmail : inputSubEmail,
+          businessNumber: inputBusinessNumber,
+          storeLocation: inputBusinessAddress,
+          ageGroup: inputAgeGroup,
+          code: "STORE"}),
+        error: function(myval){console.log("에러"+myval)},
+        success: function(myval){
+          console.log("성공"+myval);
+
+          alert("회원가입 완료되었습니다");
+          location.replace("/login-page");
+
+        }
+      })
+
+    }else if(!COMM_register_emailNumberCheck){
+      alert("이메일 인증번호를 체크해주세요!");
+    } else if(!COMM_register_businessInfo){
+      alert("사업자인증을 해주세요!");
+    } else if(!COMM_register_buisnessloc){
+      alert("사업자 주소를 입력해주세요");
+    } else if(!COMM_register_acceptTerms){
+      alert("개인정보 및 이용약관에 동의해주세요");
+    } else if(!email_subEmail_check){
+      alert("이메일과 보조 이메일이 동일하면 안됩니다");
+    }
+
+  })
+
+  $("#COMM_register_btn_oauth_reviewer_regist").click(function(){         //common-oauth-register 체험단 회원가입
+    let inputSubEmail = $("#COMM_register_input_email").val();
+    let inputEmail = $("#Input_ID").val();
+    let inputNickname = $("#Input_NickName").val();
+    let inputAgeGroup = $("#Input_AgeGroup").val()
+
+
+    let email_subEmail_check = false;
+    if(inputEmail!=inputSubEmail)
+      email_subEmail_check = true;
+
+    if(COMM_register_emailNumberCheck&&COMM_register_nickNameCheck&&email_subEmail_check){
+
+      $.ajax({
+        method: "post",
+        url : "/api/google/register",
+        contentType: "application/json",
+        data: JSON.stringify({
+          email : inputEmail,
+          subEmail : inputSubEmail,
+          nickname: inputNickname,
+          ageGroup: inputAgeGroup,
+          code: "CUSTOMER"}),
+        error: function(myval){console.log("에러"+myval)},
+        success: function(myval){
+          console.log("성공"+myval);
+
+          alert("회원가입 완료되었습니다");
+          location.replace("/login-page");
+
+        }
+      })
+
+      //$("#COMM_register_form_reviewer_regist").attr({"action": "/auth?pagecode=reviewer_regist", "method":"post"}).submit();
+    }else if(!COMM_register_emailNumberCheck){
+      alert("이메일 인증번호를 체크해주세요!");
+    } else if(!COMM_register_nickNameCheck){
+      alert("닉네임 중복확인을 체크해주세요!");
+    } else if(!COMM_register_acceptTerms){
+      alert("개인정보 및 이용약관를 확인하고 동의해주세요");
+    }else if(!email_subEmail_check){
+      alert("이메일과 보조 이메일이 동일하면 안됩니다")
+    }
+  })
+
 })
 
 $("#COMM_register_reviewer_agreebtn").click(function(){ // COMM_register 개인정보 및 이용약관 확인 버튼

--- a/src/main/webapp/common-google-register.jsp
+++ b/src/main/webapp/common-google-register.jsp
@@ -75,7 +75,7 @@
 
                             <div class="card-body">
                                 <div class="pt-4 pb-2">
-                                    <h5 class="card-title text-center pb-0 fs-4">OAUTH 회원가입</h5>
+                                    <h5 class="card-title text-center pb-0 fs-4">구글 유저 회원가입</h5>
                                 </div>
                                 <div class="card">
                                     <input type="hidden" id="OauthUser" value="${userInfo.email}"/>
@@ -354,7 +354,7 @@
                                                     <div class="col-12">
                                                         <button class="btn btn-primary w-100"
                                                                 type="button"
-                                                                id="COMM_register_btn_reviewer_regist">
+                                                                id="COMM_register_btn_oauth_reviewer_regist">
                                                             회원가입
                                                         </button>
                                                     </div>
@@ -631,7 +631,7 @@
                                                         </div>
                                                         <div class="col-12">
                                                             <button class="btn btn-primary w-100"
-                                                                    id="COMM_register_btn_Boss_regist"
+                                                                    id="COMM_register_btn_oauth_Boss_regist"
                                                                     type="submit">회원가입
                                                             </button>
                                                         </div>

--- a/src/main/webapp/common-login.jsp
+++ b/src/main/webapp/common-login.jsp
@@ -6,6 +6,10 @@
   To change this template use File | Settings | File Templates.
 --%>
 <%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+<%@ taglib uri="http://www.springframework.org/tags/form" prefix="form" %>
+<%@ taglib uri="http://www.springframework.org/tags" prefix="spring" %>
+
 <!DOCTYPE html>
 <html lang="en">
 
@@ -105,7 +109,7 @@
                                         <p class="small mb-0">회원이 아니신가요?     <a href="/auth?pagecode=register">회원가입 하러가기</a></p>
                                     </div>
                                     <div class="col-12">
-                                        <a href="/login/GOOGLE"><img src="https://test.codemshop.com/wp-content/plugins/mshop-mcommerce-premium-s2/lib/mshop-members-s2/assets/images/social/logo/Google.png" style="border: 1px solid #bbbbbb;  border-radius:15%;"></a>
+                                        <a href="${googleLoginUrl}"><img src="https://test.codemshop.com/wp-content/plugins/mshop-mcommerce-premium-s2/lib/mshop-members-s2/assets/images/social/logo/Google.png" style="border: 1px solid #bbbbbb;  border-radius:15%;"></a>
                                     </div>
                                 </form>
 

--- a/src/main/webapp/common-oauth-register.jsp
+++ b/src/main/webapp/common-oauth-register.jsp
@@ -1,0 +1,689 @@
+<%--
+  Created by IntelliJ IDEA.
+  User: rlagk
+  Date: 2024-06-04
+  Time: 오후 12:14
+  To change this template use File | Settings | File Templates.
+--%>
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <meta content="width=device-width, initial-scale=1.0" name="viewport">
+
+    <title>Pages / Register - NiceAdmin Bootstrap Template</title>
+    <meta content="" name="description">
+    <meta content="" name="keywords">
+
+    <!-- Favicons -->
+    <link href="assets/img/favicon.png" rel="icon">
+    <link href="assets/img/apple-touch-icon.png" rel="apple-touch-icon">
+
+    <!-- Google Fonts -->
+    <link href="https://fonts.gstatic.com" rel="preconnect">
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,300i,400,400i,600,600i,700,700i|Nunito:300,300i,400,400i,600,600i,700,700i|Poppins:300,300i,400,400i,500,500i,600,600i,700,700i"
+          rel="stylesheet">
+
+    <!-- Vendor CSS Files -->
+    <link href="assets/vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
+    <link href="assets/vendor/bootstrap-icons/bootstrap-icons.css" rel="stylesheet">
+    <link href="assets/vendor/boxicons/css/boxicons.min.css" rel="stylesheet">
+    <link href="assets/vendor/quill/quill.snow.css" rel="stylesheet">
+    <link href="assets/vendor/quill/quill.bubble.css" rel="stylesheet">
+    <link href="assets/vendor/remixicon/remixicon.css" rel="stylesheet">
+    <link href="assets/vendor/simple-datatables/style.css" rel="stylesheet">
+
+    <!-- Template Main CSS File -->
+    <link href="assets/css/style.css" rel="stylesheet">
+    <link href="assets/css/hr.css" rel="stylesheet">
+    <!-- =======================================================
+    * Template Name: NiceAdmin
+    * Template URL: https://bootstrapmade.com/nice-admin-bootstrap-admin-html-template/
+    * Updated: Apr 20 2024 with Bootstrap v5.3.3
+    * Author: BootstrapMade.com
+    * License: https://bootstrapmade.com/license/
+    ======================================================== -->
+    <script
+            src="https://code.jquery.com/jquery-3.7.1.js"
+            integrity="sha256-eKhayi8LEQwp4NKxN+CfCh+3qOVUtJn3QNZ0TciWLP4="
+            crossorigin="anonymous"></script>
+    <script src="https://t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js"></script>
+</head>
+
+<body>
+
+<main>
+    <div class="container">
+
+        <section
+                class="section register min-vh-100 d-flex flex-column align-items-center justify-content-center py-4">
+            <div class="container">
+                <div class="row justify-content-center">
+                    <div class="col-lg-4 col-md-6 d-flex flex-column align-items-center justify-content-center">
+
+                        <div class="d-flex justify-content-center py-4">
+                            <a href="#" class="logo d-flex align-items-center w-auto">
+                                <img src="assets/img/logo/logo-vertical.png" alt="" style="width: 50px;
+    margin-top: 20px;">
+                                <span class="d-none d-lg-block">Freview</span>
+                            </a>
+                        </div><!-- End Logo -->
+
+                        <div class="card mb-3">
+
+                            <div class="card-body">
+                                <div class="pt-4 pb-2">
+                                    <h5 class="card-title text-center pb-0 fs-4">OAUTH 회원가입</h5>
+                                </div>
+                                <div class="card">
+                                    <input type="hidden" id="OauthUser" value="${userInfo.email}"/>
+                                    <div class="card-body" style=width:500px>
+                                        <!-- Bordered Tabs Justified -->
+                                        <ul class="nav nav-tabs nav-tabs-bordered d-flex"
+                                            id="borderedTabJustified" role="tablist">
+                                            <li class="nav-item flex-fill" role="presentation">
+                                                <button class="nav-link w-100" id="home-tab"
+                                                        data-bs-toggle="tab"
+                                                        data-bs-target="#bordered-justified-home"
+                                                        type="button" role="tab"
+                                                        aria-controls="home" aria-selected="false"
+                                                        tabindex="-1">체험단
+                                                </button>
+                                            </li>
+                                            <li class="nav-item flex-fill" role="presentation">
+                                                <button class="nav-link w-100 active"
+                                                        id="profile-tab" data-bs-toggle="tab"
+                                                        data-bs-target="#bordered-justified-profile"
+                                                        type="button" role="tab"
+                                                        aria-controls="profile"
+                                                        aria-selected="true">Store
+                                                </button>
+                                            </li>
+                                        </ul>
+                                        <div class="tab-content pt-2"
+                                             id="borderedTabJustifiedContent">
+                                            <div class="tab-pane fade" id="bordered-justified-home"
+                                                 role="tabpanel" aria-labelledby="home-tab">
+                                                <p>협찬을 제공받고 온라인 리뷰를 제출하는 체험단 입니다</p>
+                                                <form class="row g-3 needs-validation"
+                                                      id="COMM_register_form_reviewer_regist"
+                                                      novalidate>
+                                                    <div class="col-12">
+                                                        <label for="Input_ID"
+                                                               class="form-label">이메일</label>
+                                                        <div style=display:flex>
+                                                            <input type="text" name="email"
+                                                                   class="form-control"
+                                                                   id="Input_ID" value="${userInfo.email}" readonly>
+                                                        </div>
+                                                        <div class="invalid-feedback">이메일을 입력해주세요
+                                                        </div>
+                                                        <div id="COMM_register_IDavail"
+                                                             class="remove"
+                                                             style=color:cornflowerblue>이메일 사용 가능합니다
+                                                        </div>
+                                                        <div id="COMM_register_IDdeny"
+                                                             class="remove" style=color:red>이메일 사용
+                                                            불가합니다
+                                                        </div>
+                                                    </div>
+                                                    <div class="col-12">
+                                                        <label for="COMM_register_input_email"
+                                                               class="form-label">보조 이메일</label>
+                                                        <div style="font-size: small; color: blue">이메일 찾기시 보조 이메일로 회원임을 확인합니다</div>
+                                                        <div style=display:flex>
+                                                            <input type="email" name="sub_email"
+                                                                   class="form-control"
+                                                                   id="COMM_register_input_email"
+                                                                   required>
+                                                            <button type="button"
+                                                                    class="btn btn-outline-primary"
+                                                                    id="COMM_register_emailBtn"
+                                                                    style=
+                                                                            "text-align: center;
+                                                                    font-size: 13px;
+                                                                    width: 110px;
+                                                                    margin-left: 5px; "
+                                                            >인증번호
+                                                            </button>
+                                                        </div>
+                                                        <div class="invalid-feedback">이메일을 입력해주세요
+                                                        </div>
+                                                        <div class="col-12">
+                                                            <label for="COMM_register_input_emailNumber"
+                                                                   class="form-label">인증번호확인</label>
+                                                            <div style=display:flex>
+                                                                <input type="email" name="text"
+                                                                       class="form-control"
+                                                                       id="COMM_register_input_emailNumber"
+                                                                       required disabled>
+                                                                <button type="button"
+                                                                        class="btn btn-outline-primary"
+                                                                        id="COMM_register_emailNumberBtn"
+                                                                        style=
+                                                                                "text-align: center;
+                                                                    font-size: 13px;
+                                                                    width: 110px;
+                                                                    margin-left: 5px; "
+                                                                        disabled>확인
+                                                                </button>
+                                                            </div>
+                                                            <div id="COMM_register_emailCheckNumberVali"
+                                                                 class="remove"
+                                                                 style=color:cornflowerblue>인증 성공
+                                                            </div>
+                                                        </div>
+                                                    </div>
+
+                                                    <div class="col-12">
+                                                        <label for="Input_ID"
+                                                               class="form-label">닉네임</label>
+                                                        <div style=display:flex>
+                                                            <input type="text" name="nickname"
+                                                                   class="form-control"
+                                                                   id="Input_NickName" required>
+                                                            <button type="button"
+                                                                    class="btn btn-outline-primary"
+                                                                    id="COMM_register_NickNamecheckBTN"
+                                                                    style=
+                                                                            "text-align: center;
+                                                                    font-size: 13px;
+                                                                    width: 110px;
+                                                                    margin-left: 5px; "
+                                                            >중복확인
+                                                            </button>
+                                                        </div>
+                                                        <div class="invalid-feedback">닉네임을 입력해주세요
+                                                        </div>
+                                                        <div id="COMM_register_NickNameavail"
+                                                             class="remove"
+                                                             style=color:cornflowerblue>닉네임 사용 가능합니다
+                                                        </div>
+                                                        <div id="COMM_register_NickNamedeny"
+                                                             class="remove" style=color:red>닉네임 사용
+                                                            불가합니다
+                                                        </div>
+                                                    </div>
+                                                    <div class="col-12">
+                                                        <label for="Input_AgeGroup"
+                                                               class="form-label">연령대</label>
+                                                        <select id="Input_AgeGroup" name="age_group"
+                                                                style="margin-left: 10px;
+                                                                        width: 100px;"
+                                                                required>
+                                                            <option value="10대">10대</option>
+                                                            <option value="20대">20대</option>
+                                                            <option value="30대">30대</option>
+                                                            <option value="40대">40대</option>
+                                                            <option value="50대">50대</option>
+                                                            <option value="60대">60대</option>
+                                                            <option value="70대">70대</option>
+                                                            <option value="80대">80대</option>
+                                                            <option value="90대">90대</option>
+                                                        </select>
+                                                        <div class="invalid-feedback">연령대를 입력해주세요
+                                                        </div>
+                                                    </div>
+                                                    <div class="col-12">
+
+                                                        <div class="form-check">
+                                                            <input class="form-check-input"
+                                                                   name="terms" type="checkbox"
+                                                                   value=""
+                                                                   id="reviewer_acceptTerms"
+                                                                   required disabled>
+                                                            <button type="button"
+                                                                    class="btn btn-primary"
+                                                                    data-bs-toggle="modal"
+                                                                    data-bs-target="#modalDialogScrollable"
+                                                                    style="color: blue;
+                                                                           background: none;
+                                                                           border: none;"
+                                                            >
+                                                                개인정보 및 이용약관에 동의합니다.
+                                                            </button>
+                                                            <div class="modal fade"
+                                                                 id="modalDialogScrollable"
+                                                                 tabindex="-1">
+                                                                <div class="modal-dialog modal-dialog-scrollable">
+                                                                    <div class="modal-content">
+                                                                        <div class="modal-header">
+                                                                            <h5 class="modal-title">
+                                                                                개인정보 및 이용약관</h5>
+                                                                            <button type="button"
+                                                                                    class="btn-close"
+                                                                                    data-bs-dismiss="modal"
+                                                                                    aria-label="Close"></button>
+                                                                        </div>
+                                                                        <div class="modal-body">
+                                                                            <h4>개인정보 수집 및 이용약관</h4>
+                                                                            <h5>1. 개인정보의 수집 및 이용
+                                                                                목적</h5>
+                                                                            <p>1.1. 식당 리뷰를 작성하는 체험단
+                                                                                회원에게서는 다음과 같은 개인정보를
+                                                                                수집합니다.</p>
+                                                                            <ul>
+                                                                                <li>성명</li>
+                                                                                <li>연락처 (이메일 주소,
+                                                                                    전화번호 등)
+                                                                                </li>
+                                                                                <li>나이 또는 생년월일</li>
+                                                                                <li>거주지 (선택사항)</li>
+                                                                                <li>SNS 계정 정보
+                                                                                    (선택사항)
+                                                                                </li>
+                                                                            </ul>
+                                                                            <h5>2. 개인정보의 수집 방법</h5>
+                                                                            <p>2.1. 개인정보는 회원 가입 시,
+                                                                                서비스 이용 과정에서 자발적으로
+                                                                                제공되는 경우, 이벤트나 프로모션
+                                                                                참여 시 수집될 수 있습니다.</p>
+                                                                            <h5>3. 개인정보의 이용</h5>
+                                                                            <p>3.1. 체험단 회원의 개인정보는
+                                                                                다음과 같은 목적으로
+                                                                                이용됩니다.</p>
+
+                                                                            <h5>4. 개인정보의 보유 및 이용
+                                                                                기간</h5>
+                                                                            4.1. 개인정보는 회원 탈퇴 시 또는
+                                                                            개인정보 보호 및 관리 정책에 따라 명시된
+                                                                            기간 이후에는 파기됩니다.
+
+                                                                            <h5>5. 개인정보의 제3자 제공</h5>
+                                                                            5.1. 회사는 법령에 따른 경우 또는
+                                                                            회원의 동의가 있는 경우를 제외하고는
+                                                                            개인정보를 외부에 제공하지 않습니다.
+
+                                                                            <h5>6. 개인정보의 파기 절차 및
+                                                                                방법</h5>
+                                                                            6.1. 개인정보는 수집 및 이용 목적이
+                                                                            달성된 후에는 관련 법령에 따라 안전하게
+                                                                            파기됩니다.
+
+                                                                            <h5>7. 개인정보 관리책임자 및
+                                                                                연락처</h5>
+                                                                            7.1. 회원은 개인정보에 관한 불만이나
+                                                                            문의사항을 개인정보 관리책임자에게 연락할 수
+                                                                            있습니다.
+                                                                            <ul>
+                                                                                <li>이름: 윤승</li>
+                                                                                <li>이메일:
+                                                                                    yoon@gmail.com
+                                                                                </li>
+                                                                                <li>전화번호:
+                                                                                    010-7777-7777
+                                                                                </li>
+                                                                            </ul>
+
+                                                                            <h5>8. 기타</h5>
+                                                                            8.1. 본 약관은 법령이나 회사의 정책
+                                                                            변경에 따라 수정될 수 있으며, 변경 사항은
+                                                                            서비스 내 공지를 통해 고지됩니다.
+
+                                                                            <p>위의 개인정보 수집 및 이용약관은
+                                                                                회원가입 시 동의 후 서비스를
+                                                                                이용하실 수 있습니다. 이를
+                                                                                참고하시어 동의 여부를 결정해주시기
+                                                                                바랍니다.</p>
+
+                                                                        </div>
+                                                                        <div class="modal-footer">
+                                                                            <button type="button"
+                                                                                    class="btn btn-secondary"
+                                                                                    data-bs-dismiss="modal"
+                                                                                    id="COMM_register_reviewer_disagreebtn">
+                                                                                나가기
+                                                                            </button>
+                                                                            <button type="button"
+                                                                                    class="btn btn-primary"
+                                                                                    id="COMM_register_reviewer_agreebtn">
+                                                                                동의
+                                                                            </button>
+                                                                        </div>
+                                                                    </div>
+                                                                </div>
+                                                            </div>
+
+                                                            <div class="invalid-feedback">You must
+                                                                agree before submitting.
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                    <div class="col-12">
+                                                        <button class="btn btn-primary w-100"
+                                                                type="button"
+                                                                id="COMM_register_btn_reviewer_regist">
+                                                            회원가입
+                                                        </button>
+                                                    </div>
+                                                    <div class="col-12">
+                                                        <p class="small mb-0">Already have an
+                                                            account? <a href="pages-login.html">Log
+                                                                in</a></p>
+                                                    </div>
+                                                </form>
+                                            </div>
+                                            <div class="tab-pane fade active show"
+                                                 id="bordered-justified-profile" role="tabpanel"
+                                                 aria-labelledby="profile-tab">
+                                                <p>협찬을 제공하고 온라인 리뷰를 제공받는 Store 입니다</p>
+                                                <form class="row g-3 needs-validation"
+                                                      id="COMM_register_form_Boss_regist"
+                                                      novalidate>
+                                                    <div class="col-12">
+                                                        <label for="Input_ID"
+                                                               class="form-label">이메일</label>
+                                                        <div style=display:flex>
+                                                            <input type="text" name="id"
+                                                                   class="form-control"
+                                                                   id="Boss_Input_ID" value="${userInfo.email}" readonly>
+                                                        </div>
+                                                        <div class="invalid-feedback">이메일을 입력해주세요
+                                                        </div>
+                                                        <div id="COMM_register_Boss_IDavail"
+                                                             class="remove"
+                                                             style=color:cornflowerblue>이메일 사용 가능합니다
+                                                        </div>
+                                                        <div id="COMM_register_Boss_IDdeny"
+                                                             class="remove" style=color:red>이메일 사용
+                                                            불가합니다
+                                                        </div>
+                                                    </div>
+                                                    <div class="col-12">
+                                                        <label for="COMM_register_input_Boss_email"
+                                                               class="form-label">보조 이메일</label>
+                                                        <div style="font-size: small; color: blue">이메일 찾기시 보조 이메일로 회원임을 확인합니다</div>
+                                                        <div style=display:flex>
+                                                            <input type="email" name="email"
+                                                                   class="form-control"
+                                                                   id="COMM_register_input_Boss_email"
+                                                                   required>
+                                                            <button type="button"
+                                                                    class="btn btn-outline-primary"
+                                                                    id="COMM_register_Boss_emailBtn"
+                                                                    style=
+                                                                            "text-align: center;
+                                                                    font-size: 13px;
+                                                                    width: 110px;
+                                                                    margin-left: 5px; "
+                                                            >인증번호
+                                                            </button>
+                                                        </div>
+                                                        <div class="invalid-feedback">보조 이메일을 입력해주세요
+                                                        </div>
+                                                        <div class="col-12">
+                                                            <label for="COMM_register_input_Boss_emailNumber"
+                                                                   class="form-label">인증번호확인</label>
+                                                            <div style=display:flex>
+                                                                <input type="email" name="text"
+                                                                       class="form-control"
+                                                                       id="COMM_register_input_Boss_emailNumber"
+                                                                       required disabled>
+                                                                <button type="button"
+                                                                        class="btn btn-outline-primary"
+                                                                        id="COMM_register_Boss_emailNumberBtn"
+                                                                        style=
+                                                                                "text-align: center;
+                                                                    font-size: 13px;
+                                                                    width: 110px;
+                                                                    margin-left: 5px; "
+                                                                        disabled>확인
+                                                                </button>
+                                                            </div>
+                                                            <div id="COMM_register_Boss_emailCheckNumberVali"
+                                                                 class="remove"
+                                                                 style=color:cornflowerblue>인증 성공
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                    <div class="col-12">
+                                                        <label for="Input_Boss_AgeGroup"
+                                                               class="form-label">연령대</label>
+                                                        <select id="Input_Boss_AgeGroup"
+                                                                name="agegroup"
+                                                                style="margin-left: 10px;
+                                                                        width: 100px;"
+                                                                required>
+                                                            <option value="10대">10대</option>
+                                                            <option value="20대">20대</option>
+                                                            <option value="30대">30대</option>
+                                                            <option value="40대">40대</option>
+                                                            <option value="50대">50대</option>
+                                                            <option value="60대">60대</option>
+                                                            <option value="70대">70대</option>
+                                                            <option value="80대">80대</option>
+                                                            <option value="90대">90대</option>
+                                                        </select>
+                                                        <div class="invalid-feedback">연령대를 입력해주세요
+                                                        </div>
+                                                    </div>
+                                                    <div class="col-12">
+                                                        <label for="COMM_register_input_Boss_buisnessInfo"
+                                                               class="form-label">사업자등록번호</label>
+                                                        <div style="display:flex">
+                                                            <input type="text" class="form-control"
+                                                                   id="COMM_register_input_Boss_buisnessInfo"
+                                                                   name="buisness_number"
+                                                                   placeholder="000-00-00000 형식으로 입력"
+                                                                   required>
+                                                            <button type="button"
+                                                                    class="btn btn-outline-primary"
+                                                                    id="COMM_register_Boss_buisnessInfobts"
+                                                                    style=
+                                                                            "text-align: center;
+                                                                        font-size: 9px;
+                                                                        width: 110px;
+                                                                        margin-left: 5px; "
+                                                            >사업자인증하기
+                                                            </button>
+                                                        </div>
+                                                    </div>
+                                                    <div class="invalid-feedback">사업자등록번호를 입력해주세요
+                                                    </div>
+                                                    <div id="COMM_register_Boss_buisnessInfoavail"
+                                                         class="remove" style=color:cornflowerblue>
+                                                        인증 완료되었습니다
+                                                    </div>
+                                                    <div id="COMM_register_Boss_buisnessInfoDuplicatedvali"
+                                                         class="remove" style=color:cornflowerblue>
+                                                        가입 가능한 사업자등록번호입니다
+                                                    </div>
+                                                    <div class="col-12">
+                                                        <label for="COMM_register_input_Boss_addressbtn"
+                                                               class="form-label">주소 검색</label>
+                                                        <button type="button"
+                                                                class="btn btn-outline-primary"
+                                                                id="COMM_register_input_Boss_addressbtn"
+                                                                style=
+                                                                        "text-align: center;
+                                                                    font-size: 9px;
+                                                                    width: 210px;
+                                                                    margin-left: 5px; " disabled>
+                                                            주소검색
+                                                        </button>
+                                                    </div>
+                                                    <div class="col-12">
+                                                        <label for="COMM_register_input_Boss_buisnessaddress"
+                                                               class="form-label">사업자 주소</label>
+                                                        <input type="text" class="form-control"
+                                                               name="store_loc"
+                                                               id="COMM_register_input_Boss_buisnessaddress"
+                                                               required disabled>
+                                                    </div>
+
+                                                    <div class="col-12">
+                                                        <div class="form-check">
+                                                            <input class="form-check-input"
+                                                                   name="terms" type="checkbox"
+                                                                   value=""
+                                                                   id="reviewer_Boss_acceptTerms"
+                                                                   required disabled>
+                                                            <button type="button"
+                                                                    class="btn btn-primary"
+                                                                    data-bs-toggle="modal"
+                                                                    data-bs-target="#modalDialogScrollable1"
+                                                                    style="color: blue;
+                                                                           background: none;
+                                                                           border: none;"
+                                                            >
+                                                                개인정보 및 이용약관에 동의합니다.
+                                                            </button>
+                                                            <div class="modal fade"
+                                                                 id="modalDialogScrollable1"
+                                                                 tabindex="-1">
+                                                                <div class="modal-dialog modal-dialog-scrollable">
+                                                                    <div class="modal-content">
+                                                                        <div class="modal-header">
+                                                                            <h5 class="modal-title">
+                                                                                개인정보 및 이용약관</h5>
+                                                                            <button type="button"
+                                                                                    class="btn-close"
+                                                                                    data-bs-dismiss="modal"
+                                                                                    aria-label="Close"></button>
+                                                                        </div>
+                                                                        <div class="modal-body">
+                                                                            <h4>개인정보 수집 및 이용약관</h4>
+                                                                            <h5>1. 개인정보의 수집 및 이용
+                                                                                목적</h5>
+                                                                            <p>1.2. 식당을 운영하는 Store으로서
+                                                                                회원 가입하는 경우, 다음과 같은
+                                                                                개인정보를 수집합니다.</p>
+                                                                            <ul>
+                                                                                <li>사업자 등록 번호</li>
+                                                                                <li>업체명 또는 상호</li>
+                                                                                <li>대표자 성명</li>
+                                                                                <li>대표자 연락처</li>
+                                                                                <li>사업장 주소</li>
+                                                                            </ul>
+                                                                            <h5>2. 개인정보의 수집 방법</h5>
+                                                                            <p>2.1. 개인정보는 회원 가입 시,
+                                                                                서비스 이용 과정에서 자발적으로
+                                                                                제공되는 경우, 이벤트나 프로모션
+                                                                                참여 시 수집될 수 있습니다.</p>
+                                                                            <h5>3. 개인정보의 이용</h5>
+                                                                            <p>3.2. Store 회원의 개인정보는
+                                                                                다음과 같은 목적으로
+                                                                                이용됩니다.</p>
+
+                                                                            <h5>4. 개인정보의 보유 및 이용
+                                                                                기간</h5>
+                                                                            4.1. 개인정보는 회원 탈퇴 시 또는
+                                                                            개인정보 보호 및 관리 정책에 따라 명시된
+                                                                            기간 이후에는 파기됩니다.
+
+                                                                            <h5>5. 개인정보의 제3자 제공</h5>
+                                                                            5.1. 회사는 법령에 따른 경우 또는
+                                                                            회원의 동의가 있는 경우를 제외하고는
+                                                                            개인정보를 외부에 제공하지 않습니다.
+
+                                                                            <h5>6. 개인정보의 파기 절차 및
+                                                                                방법</h5>
+                                                                            6.1. 개인정보는 수집 및 이용 목적이
+                                                                            달성된 후에는 관련 법령에 따라 안전하게
+                                                                            파기됩니다.
+
+                                                                            <h5>7. 개인정보 관리책임자 및
+                                                                                연락처</h5>
+                                                                            7.1. 회원은 개인정보에 관한 불만이나
+                                                                            문의사항을 개인정보 관리책임자에게 연락할 수
+                                                                            있습니다.
+                                                                            <ul>
+                                                                                <li>이름: 윤승</li>
+                                                                                <li>이메일:
+                                                                                    yoon@gmail.com
+                                                                                </li>
+                                                                                <li>전화번호:
+                                                                                    010-7777-7777
+                                                                                </li>
+                                                                            </ul>
+
+                                                                            <h5>8. 기타</h5>
+                                                                            8.1. 본 약관은 법령이나 회사의 정책
+                                                                            변경에 따라 수정될 수 있으며, 변경 사항은
+                                                                            서비스 내 공지를 통해 고지됩니다.
+
+                                                                            <p>위의 개인정보 수집 및 이용약관은
+                                                                                회원가입 시 동의 후 서비스를
+                                                                                이용하실 수 있습니다. 이를
+                                                                                참고하시어 동의 여부를 결정해주시기
+                                                                                바랍니다.</p>
+
+                                                                        </div>
+                                                                        <div class="modal-footer">
+                                                                            <button type="button"
+                                                                                    class="btn btn-secondary"
+                                                                                    data-bs-dismiss="modal"
+                                                                                    id="COMM_register_Boss_disagreebtn">
+                                                                                나가기
+                                                                            </button>
+                                                                            <button type="button"
+                                                                                    class="btn btn-primary"
+                                                                                    id="COMM_register_Boss_agreebtn">
+                                                                                동의
+                                                                            </button>
+                                                                        </div>
+                                                                    </div>
+                                                                </div>
+                                                            </div>
+
+                                                        </div>
+                                                        <div class="col-12">
+                                                            <button class="btn btn-primary w-100"
+                                                                    id="COMM_register_btn_Boss_regist"
+                                                                    type="submit">회원가입
+                                                            </button>
+                                                        </div>
+                                                        <div class="col-12">
+                                                            <p class="small mb-0">Already have an
+                                                                account? <a href="pages-login.html">Log
+                                                                    in</a></p>
+                                                        </div>
+                                                    </div>
+                                                </form>
+                                            </div>
+                                        </div><!-- End Bordered Tabs Justified -->
+                                    </div>
+                                </div>
+
+
+                            </div>
+                        </div>
+
+                        <div class="credits">
+                            <!-- All the links in the footer should remain intact. -->
+                            <!-- You can delete the links only if you purchased the pro version. -->
+                            <!-- Licensing information: https://bootstrapmade.com/license/ -->
+                            <!-- Purchase the pro version with working PHP/AJAX contact form: https://bootstrapmade.com/nice-admin-bootstrap-admin-html-template/ -->
+                            Designed by <a href="https://bootstrapmade.com/">BootstrapMade</a>
+                        </div>
+
+                    </div>
+                </div>
+            </div>
+
+        </section>
+
+    </div>
+</main><!-- End #main -->
+
+<a href="#" class="back-to-top d-flex align-items-center justify-content-center"><i
+        class="bi bi-arrow-up-short"></i></a>
+
+<!-- Vendor JS Files -->
+<script src="assets/vendor/apexcharts/apexcharts.min.js"></script>
+<script src="assets/vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
+<script src="assets/vendor/chart.js/chart.umd.js"></script>
+<script src="assets/vendor/echarts/echarts.min.js"></script>
+<script src="assets/vendor/quill/quill.js"></script>
+<script src="assets/vendor/simple-datatables/simple-datatables.js"></script>
+<script src="assets/vendor/tinymce/tinymce.min.js"></script>
+<script src="assets/vendor/php-email-form/validate.js"></script>
+
+<!-- Template Main JS File -->
+<script src="assets/js/main.js"></script>
+<script src="assets/js/hr.js"></script>
+</body>
+
+</html>


### PR DESCRIPTION
**구글 이미지 클릭**
![image](https://github.com/user-attachments/assets/545d63eb-287e-4d99-b4cf-d4ee0914f28c)

**신규 회원이면 회원가입 진행**
![image](https://github.com/user-attachments/assets/4830b332-39a1-4358-bc7a-7704b3247d95)
![image](https://github.com/user-attachments/assets/c0c3e34d-8d36-4e03-9804-05a973c4085b)

- 구글 아이디을 이메일로 사용
- 기존 회원가입과 다르게 비밀번호 받지 않음

**기존 회원은 토큰 발급후 메인 페이지로 이동**
![image](https://github.com/user-attachments/assets/aaed25de-6ea9-460d-afe6-8b05c7072ecb)
- AccessToken Http header에 저장
- RefreshToken 쿠키에 저장
- AccesToekn안에 입력된 role을 확인하고 회원별 메인페이지로 이동합니다.
