### PR TITLE
[feat-customer] 체험단 > MY > 알림 페이지 뷰 - API 연동 ( 체험단 > MY > 알림 페이지 구현 완료 )

### DIFF
--- a/src/main/java/com/nuguna/freview/customer/constant/CustomerReviewLogConstant.java
+++ b/src/main/java/com/nuguna/freview/customer/constant/CustomerReviewLogConstant.java
@@ -2,7 +2,8 @@ package com.nuguna.freview.customer.constant;
 
 public class CustomerReviewLogConstant {
 
-  public static final int CUSTOMER_MY_BRAND_REVIEW_LOG_SIZE = 5;
-  public static final int CUSTOMER_REVIEW_LOG_FIRST_PAGE_NUMBER = 1;
-  public static final int CUSTOMER_REVIEW_LOG_PAGE_BLOCK_SIZE = 5;
+  public static final int CUSTOMER_MY_BRAND_REVIEW_LOG_PAGE_SIZE = 5;
+  public static final int CUSTOMER_MY_BRAND_REVIEW_LOG_PAGE_BLOCK_SIZE = 5;
+  public static final int CUSTOMER_OTHER_BRAND_REVIEW_LOG_PAGE_SIZE = 5;
+  public static final int CUSTOMER_OTHER_BRAND_REVIEW_LOG_PAGE_BLOCK_SIZE = 5;
 }

--- a/src/main/java/com/nuguna/freview/customer/controller/page/CustomerMyPageController.java
+++ b/src/main/java/com/nuguna/freview/customer/controller/page/CustomerMyPageController.java
@@ -2,6 +2,7 @@ package com.nuguna.freview.customer.controller.page;
 
 import com.nuguna.freview.customer.dto.response.page.CustomerMyBrandPageInfoResponseDTO;
 import com.nuguna.freview.customer.service.CustomerPageService;
+import com.nuguna.freview.customer.service.CustomerUtilService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
@@ -16,10 +17,13 @@ import org.springframework.web.bind.annotation.RequestParam;
 public class CustomerMyPageController {
 
   private final CustomerPageService customerPageService;
+  private final CustomerUtilService customerUtilService;
 
   @Autowired
-  public CustomerMyPageController(CustomerPageService customerPageService) {
+  public CustomerMyPageController(CustomerPageService customerPageService,
+      CustomerUtilService customerUtilService) {
     this.customerPageService = customerPageService;
+    this.customerUtilService = customerUtilService;
   }
 
   @RequestMapping(value = "/brand-info", method = RequestMethod.GET)
@@ -35,28 +39,28 @@ public class CustomerMyPageController {
 
   @RequestMapping(value = "/experience", method = RequestMethod.GET)
   public String customerMyExperiencePage(@RequestParam Long userSeq, Model model) {
-    String nickname = customerPageService.getCustomerNickname(userSeq);
+    String nickname = customerUtilService.getUserNickname(userSeq);
     model.addAttribute("nickname", nickname);
     return "customer-my-experience-info";
   }
 
   @RequestMapping(value = "/activity", method = RequestMethod.GET)
   public String customerMyActivityPage(@RequestParam Long userSeq, Model model) {
-    String nickname = customerPageService.getCustomerNickname(userSeq);
+    String nickname = customerUtilService.getUserNickname(userSeq);
     model.addAttribute("nickname", nickname);
     return "customer-my-activity-info";
   }
 
   @RequestMapping(value = "/notification", method = RequestMethod.GET)
   public String customerMyNotificationPage(@RequestParam Long userSeq, Model model) {
-    String nickname = customerPageService.getCustomerNickname(userSeq);
+    String nickname = customerUtilService.getUserNickname(userSeq);
     model.addAttribute("nickname", nickname);
     return "customer-my-notification";
   }
 
   @RequestMapping(value = "/personal-info", method = RequestMethod.GET)
   public String customerMyPersonalInfoPage(@RequestParam Long userSeq, Model model) {
-    String nickname = customerPageService.getCustomerNickname(userSeq);
+    String nickname = customerUtilService.getUserNickname(userSeq);
     model.addAttribute("nickname", nickname);
     return "customer-my-personal-info";
   }

--- a/src/main/java/com/nuguna/freview/customer/controller/page/CustomerMyPageController.java
+++ b/src/main/java/com/nuguna/freview/customer/controller/page/CustomerMyPageController.java
@@ -55,6 +55,7 @@ public class CustomerMyPageController {
   public String customerMyNotificationPage(@RequestParam Long userSeq, Model model) {
     String nickname = customerUtilService.getUserNickname(userSeq);
     model.addAttribute("nickname", nickname);
+    model.addAttribute("userSeq", userSeq);
     return "customer-my-notification";
   }
 

--- a/src/main/java/com/nuguna/freview/customer/controller/page/CustomerMyPageController.java
+++ b/src/main/java/com/nuguna/freview/customer/controller/page/CustomerMyPageController.java
@@ -34,22 +34,30 @@ public class CustomerMyPageController {
   }
 
   @RequestMapping(value = "/experience", method = RequestMethod.GET)
-  public String customerMyExperiencePage(@RequestParam(required = false) Long userSeq) {
+  public String customerMyExperiencePage(@RequestParam Long userSeq, Model model) {
+    String nickname = customerPageService.getCustomerNickname(userSeq);
+    model.addAttribute("nickname", nickname);
     return "customer-my-experience-info";
   }
 
   @RequestMapping(value = "/activity", method = RequestMethod.GET)
-  public String customerMyActivityPage(@RequestParam(required = false) Long userSeq) {
+  public String customerMyActivityPage(@RequestParam Long userSeq, Model model) {
+    String nickname = customerPageService.getCustomerNickname(userSeq);
+    model.addAttribute("nickname", nickname);
     return "customer-my-activity-info";
   }
 
   @RequestMapping(value = "/notification", method = RequestMethod.GET)
-  public String customerMyNotificationPage(@RequestParam(required = false) Long userSeq) {
+  public String customerMyNotificationPage(@RequestParam Long userSeq, Model model) {
+    String nickname = customerPageService.getCustomerNickname(userSeq);
+    model.addAttribute("nickname", nickname);
     return "customer-my-notification";
   }
 
   @RequestMapping(value = "/personal-info", method = RequestMethod.GET)
-  public String customerMyPersonalInfoPage(@RequestParam(required = false) Long userSeq) {
+  public String customerMyPersonalInfoPage(@RequestParam Long userSeq, Model model) {
+    String nickname = customerPageService.getCustomerNickname(userSeq);
+    model.addAttribute("nickname", nickname);
     return "customer-my-personal-info";
   }
 

--- a/src/main/java/com/nuguna/freview/customer/dto/response/ZzimedMeCustomerInfoDTO.java
+++ b/src/main/java/com/nuguna/freview/customer/dto/response/ZzimedMeCustomerInfoDTO.java
@@ -11,6 +11,7 @@ import lombok.NoArgsConstructor;
 public class ZzimedMeCustomerInfoDTO {
 
   // EX MESSAGE : "${nickname}" 님이 나를 찜하였습니다.
+  private Long notificationSeq;
   private Long customerSeq;
   private String nickname;
   private LocalDate createdAt;

--- a/src/main/java/com/nuguna/freview/customer/dto/response/ZzimedMeStoreInfoDTO.java
+++ b/src/main/java/com/nuguna/freview/customer/dto/response/ZzimedMeStoreInfoDTO.java
@@ -11,6 +11,7 @@ import lombok.NoArgsConstructor;
 public class ZzimedMeStoreInfoDTO {
 
   // EX MESSAGE : "${storeName}" 님이 나를 찜하였습니다.
+  private Long notificationSeq;
   private Long storeSeq;
   private String storeName;
   private LocalDate createdAt;

--- a/src/main/java/com/nuguna/freview/customer/mapper/CustomerPageMapper.java
+++ b/src/main/java/com/nuguna/freview/customer/mapper/CustomerPageMapper.java
@@ -7,8 +7,6 @@ import org.apache.ibatis.annotations.Param;
 @Mapper
 public interface CustomerPageMapper {
 
-  String getNickname(@Param("customerSeq") Long customerSeq);
-
   CustomerBrandInfoResponseDTO getBrandInfo(@Param("customerSeq") Long customerSeq);
 
 }

--- a/src/main/java/com/nuguna/freview/customer/mapper/CustomerPageMapper.java
+++ b/src/main/java/com/nuguna/freview/customer/mapper/CustomerPageMapper.java
@@ -2,10 +2,13 @@ package com.nuguna.freview.customer.mapper;
 
 import com.nuguna.freview.customer.dto.response.page.CustomerBrandInfoResponseDTO;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 @Mapper
 public interface CustomerPageMapper {
 
-  CustomerBrandInfoResponseDTO getBrandInfo(Long userSeq);
+  String getNickname(@Param("customerSeq") Long customerSeq);
+
+  CustomerBrandInfoResponseDTO getBrandInfo(@Param("customerSeq") Long customerSeq);
 
 }

--- a/src/main/java/com/nuguna/freview/customer/service/CustomerPageService.java
+++ b/src/main/java/com/nuguna/freview/customer/service/CustomerPageService.java
@@ -5,6 +5,8 @@ import com.nuguna.freview.customer.dto.response.page.CustomerOtherBrandPageInfoR
 
 public interface CustomerPageService {
 
+  String getCustomerNickname(Long customerSeq);
+
   CustomerMyBrandPageInfoResponseDTO getBrandPageInfo(Long userSeq);
 
   CustomerOtherBrandPageInfoResponseDTO getOtherBrandPageInfo(Long userSeq);

--- a/src/main/java/com/nuguna/freview/customer/service/CustomerPageService.java
+++ b/src/main/java/com/nuguna/freview/customer/service/CustomerPageService.java
@@ -5,8 +5,6 @@ import com.nuguna.freview.customer.dto.response.page.CustomerOtherBrandPageInfoR
 
 public interface CustomerPageService {
 
-  String getCustomerNickname(Long customerSeq);
-
   CustomerMyBrandPageInfoResponseDTO getBrandPageInfo(Long userSeq);
 
   CustomerOtherBrandPageInfoResponseDTO getOtherBrandPageInfo(Long userSeq);

--- a/src/main/java/com/nuguna/freview/customer/service/impl/CustomerPageServiceImpl.java
+++ b/src/main/java/com/nuguna/freview/customer/service/impl/CustomerPageServiceImpl.java
@@ -37,12 +37,6 @@ public class CustomerPageServiceImpl implements CustomerPageService {
 
   @Override
   @Transactional(readOnly = true)
-  public String getCustomerNickname(Long customerSeq) {
-    return customerPageMapper.getNickname(customerSeq);
-  }
-
-  @Override
-  @Transactional(readOnly = true)
   public CustomerMyBrandPageInfoResponseDTO getBrandPageInfo(Long userSeq) {
     CustomerBrandInfoResponseDTO brandInfo = customerPageMapper.getBrandInfo(userSeq);
 

--- a/src/main/java/com/nuguna/freview/customer/service/impl/CustomerPageServiceImpl.java
+++ b/src/main/java/com/nuguna/freview/customer/service/impl/CustomerPageServiceImpl.java
@@ -1,8 +1,9 @@
 package com.nuguna.freview.customer.service.impl;
 
-import static com.nuguna.freview.customer.constant.CustomerReviewLogConstant.CUSTOMER_MY_BRAND_REVIEW_LOG_SIZE;
-import static com.nuguna.freview.customer.constant.CustomerReviewLogConstant.CUSTOMER_REVIEW_LOG_FIRST_PAGE_NUMBER;
-import static com.nuguna.freview.customer.constant.CustomerReviewLogConstant.CUSTOMER_REVIEW_LOG_PAGE_BLOCK_SIZE;
+import static com.nuguna.freview.customer.constant.CustomerReviewLogConstant.CUSTOMER_MY_BRAND_REVIEW_LOG_PAGE_BLOCK_SIZE;
+import static com.nuguna.freview.customer.constant.CustomerReviewLogConstant.CUSTOMER_MY_BRAND_REVIEW_LOG_PAGE_SIZE;
+import static com.nuguna.freview.customer.constant.CustomerReviewLogConstant.CUSTOMER_OTHER_BRAND_REVIEW_LOG_PAGE_BLOCK_SIZE;
+import static com.nuguna.freview.customer.constant.CustomerReviewLogConstant.CUSTOMER_OTHER_BRAND_REVIEW_LOG_PAGE_SIZE;
 
 import com.nuguna.freview.customer.dto.response.PaginationInfoResponseDTO;
 import com.nuguna.freview.customer.dto.response.ReviewLogInfoDTO;
@@ -12,6 +13,7 @@ import com.nuguna.freview.customer.dto.response.page.CustomerOtherBrandPageInfoR
 import com.nuguna.freview.customer.mapper.CustomerPageMapper;
 import com.nuguna.freview.customer.mapper.CustomerReviewMapper;
 import com.nuguna.freview.customer.service.CustomerPageService;
+import com.nuguna.freview.global.util.PaginationUtil;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -43,56 +45,35 @@ public class CustomerPageServiceImpl implements CustomerPageService {
   @Transactional(readOnly = true)
   public CustomerMyBrandPageInfoResponseDTO getBrandPageInfo(Long userSeq) {
     CustomerBrandInfoResponseDTO brandInfo = customerPageMapper.getBrandInfo(userSeq);
+
+    int reviewsCount = customerReviewMapper.getReviewCount(userSeq);
+
+    PaginationInfoResponseDTO reviewPaginationInfo = PaginationUtil.makePaginationViewInfo(1,
+        reviewsCount,
+        CUSTOMER_MY_BRAND_REVIEW_LOG_PAGE_SIZE,
+        CUSTOMER_MY_BRAND_REVIEW_LOG_PAGE_BLOCK_SIZE);
+
     List<ReviewLogInfoDTO> reviewsInfo = customerReviewMapper.getReviewsInfo(userSeq, 0,
-        CUSTOMER_MY_BRAND_REVIEW_LOG_SIZE);
-    int reviewCount = customerReviewMapper.getReviewCount(userSeq);
+        CUSTOMER_MY_BRAND_REVIEW_LOG_PAGE_SIZE);
 
-    int endPage;
-    if (reviewCount % CUSTOMER_MY_BRAND_REVIEW_LOG_SIZE == 0) {
-      endPage = reviewCount / CUSTOMER_MY_BRAND_REVIEW_LOG_SIZE;
-    } else {
-      endPage = (reviewCount / CUSTOMER_MY_BRAND_REVIEW_LOG_SIZE) + 1;
-    }
-
-    if (reviewCount > CUSTOMER_MY_BRAND_REVIEW_LOG_SIZE
-        * (CUSTOMER_REVIEW_LOG_PAGE_BLOCK_SIZE - 1)) {
-      endPage = CUSTOMER_REVIEW_LOG_PAGE_BLOCK_SIZE;
-    }
-
-    boolean hasNext = (endPage > 1);
-
-    PaginationInfoResponseDTO reviewPaginationInfo
-        = new PaginationInfoResponseDTO(CUSTOMER_REVIEW_LOG_FIRST_PAGE_NUMBER,
-        CUSTOMER_REVIEW_LOG_FIRST_PAGE_NUMBER, endPage, hasNext, false);
     return new CustomerMyBrandPageInfoResponseDTO(brandInfo, reviewsInfo, reviewPaginationInfo);
   }
 
   @Override
+  @Transactional(readOnly = true)
   public CustomerOtherBrandPageInfoResponseDTO getOtherBrandPageInfo(Long userSeq) {
     CustomerBrandInfoResponseDTO otherBrandInfo = customerPageMapper.getBrandInfo(
         userSeq);
+
+    int otherReviewsCount = customerReviewMapper.getOtherReviewCount(userSeq);
+
+    PaginationInfoResponseDTO reviewPaginationInfo = PaginationUtil.makePaginationViewInfo(1,
+        otherReviewsCount, CUSTOMER_OTHER_BRAND_REVIEW_LOG_PAGE_SIZE,
+        CUSTOMER_OTHER_BRAND_REVIEW_LOG_PAGE_BLOCK_SIZE);
+
     List<ReviewLogInfoDTO> otherReviewsInfo = customerReviewMapper.getOtherReviewsInfo(userSeq, 0,
-        CUSTOMER_MY_BRAND_REVIEW_LOG_SIZE);
+        CUSTOMER_OTHER_BRAND_REVIEW_LOG_PAGE_SIZE);
 
-    int otherReviewCount = customerReviewMapper.getOtherReviewCount(userSeq);
-
-    int endPage;
-    if (otherReviewCount % CUSTOMER_MY_BRAND_REVIEW_LOG_SIZE == 0) {
-      endPage = otherReviewCount / CUSTOMER_MY_BRAND_REVIEW_LOG_SIZE;
-    } else {
-      endPage = (otherReviewCount / CUSTOMER_MY_BRAND_REVIEW_LOG_SIZE) + 1;
-    }
-
-    if (otherReviewCount > CUSTOMER_MY_BRAND_REVIEW_LOG_SIZE
-        * (CUSTOMER_REVIEW_LOG_PAGE_BLOCK_SIZE - 1)) {
-      endPage = CUSTOMER_REVIEW_LOG_PAGE_BLOCK_SIZE;
-    }
-
-    boolean hasNext = (endPage > 1);
-
-    PaginationInfoResponseDTO reviewPaginationInfo
-        = new PaginationInfoResponseDTO(CUSTOMER_REVIEW_LOG_FIRST_PAGE_NUMBER,
-        CUSTOMER_REVIEW_LOG_FIRST_PAGE_NUMBER, endPage, hasNext, false);
     return new CustomerOtherBrandPageInfoResponseDTO(otherBrandInfo, otherReviewsInfo,
         reviewPaginationInfo);
   }

--- a/src/main/java/com/nuguna/freview/customer/service/impl/CustomerPageServiceImpl.java
+++ b/src/main/java/com/nuguna/freview/customer/service/impl/CustomerPageServiceImpl.java
@@ -20,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
+@Transactional
 public class CustomerPageServiceImpl implements CustomerPageService {
 
   private final CustomerPageMapper customerPageMapper;
@@ -30,6 +31,12 @@ public class CustomerPageServiceImpl implements CustomerPageService {
       CustomerReviewMapper customerReviewMapper) {
     this.customerPageMapper = customerPageMapper;
     this.customerReviewMapper = customerReviewMapper;
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public String getCustomerNickname(Long customerSeq) {
+    return customerPageMapper.getNickname(customerSeq);
   }
 
   @Override

--- a/src/main/java/com/nuguna/freview/customer/service/impl/CustomerReviewServiceImpl.java
+++ b/src/main/java/com/nuguna/freview/customer/service/impl/CustomerReviewServiceImpl.java
@@ -1,7 +1,7 @@
 package com.nuguna.freview.customer.service.impl;
 
-import static com.nuguna.freview.customer.constant.CustomerReviewLogConstant.CUSTOMER_MY_BRAND_REVIEW_LOG_SIZE;
-import static com.nuguna.freview.customer.constant.CustomerReviewLogConstant.CUSTOMER_REVIEW_LOG_PAGE_BLOCK_SIZE;
+import static com.nuguna.freview.customer.constant.CustomerReviewLogConstant.CUSTOMER_MY_BRAND_REVIEW_LOG_PAGE_BLOCK_SIZE;
+import static com.nuguna.freview.customer.constant.CustomerReviewLogConstant.CUSTOMER_MY_BRAND_REVIEW_LOG_PAGE_SIZE;
 
 import com.nuguna.freview.customer.dto.request.CustomerMyReviewRegisterRequestDTO;
 import com.nuguna.freview.customer.dto.request.CustomerMyReviewsRetrieveRequestDTO;
@@ -58,27 +58,27 @@ public class CustomerReviewServiceImpl implements CustomerReviewService {
     Long userSeq = customerMyReviewsRetrieveRequestDTO.getUserSeq();
     Integer currentPage = customerMyReviewsRetrieveRequestDTO.getPage();
 
-    int offset = (currentPage - 1) * CUSTOMER_MY_BRAND_REVIEW_LOG_SIZE;
+    int offset = (currentPage - 1) * CUSTOMER_MY_BRAND_REVIEW_LOG_PAGE_SIZE;
     int reviewCount = customerReviewMapper.getReviewCount(userSeq);
     if (offset > reviewCount) {
       throw new IllegalReviewPageAccessException("해당하는 페이지에 대한 리뷰가 존재하지 않습니다.");
     }
     List<ReviewLogInfoDTO> reviewsInfo = customerReviewMapper.getReviewsInfo(userSeq, offset,
-        CUSTOMER_MY_BRAND_REVIEW_LOG_SIZE);
+        CUSTOMER_MY_BRAND_REVIEW_LOG_PAGE_SIZE);
 
     int startPage =
-        ((currentPage - 1) / CUSTOMER_REVIEW_LOG_PAGE_BLOCK_SIZE)
-            * CUSTOMER_REVIEW_LOG_PAGE_BLOCK_SIZE
+        ((currentPage - 1) / CUSTOMER_MY_BRAND_REVIEW_LOG_PAGE_BLOCK_SIZE)
+            * CUSTOMER_MY_BRAND_REVIEW_LOG_PAGE_BLOCK_SIZE
             + 1;
     int endPage;
-    int pageBlockThreshold = startPage + CUSTOMER_REVIEW_LOG_PAGE_BLOCK_SIZE - 1;
-    if (reviewCount >= pageBlockThreshold * CUSTOMER_MY_BRAND_REVIEW_LOG_SIZE) {
+    int pageBlockThreshold = startPage + CUSTOMER_MY_BRAND_REVIEW_LOG_PAGE_BLOCK_SIZE - 1;
+    if (reviewCount >= pageBlockThreshold * CUSTOMER_MY_BRAND_REVIEW_LOG_PAGE_SIZE) {
       endPage = pageBlockThreshold;
     } else {
-      endPage = (int) Math.ceil((double) reviewCount / CUSTOMER_MY_BRAND_REVIEW_LOG_SIZE);
+      endPage = (int) Math.ceil((double) reviewCount / CUSTOMER_MY_BRAND_REVIEW_LOG_PAGE_SIZE);
     }
     boolean hasNext = ((currentPage < endPage) || (reviewCount
-        > pageBlockThreshold * CUSTOMER_MY_BRAND_REVIEW_LOG_SIZE));
+        > pageBlockThreshold * CUSTOMER_MY_BRAND_REVIEW_LOG_PAGE_SIZE));
     boolean hasPrevious = (currentPage > 1);
 
     PaginationInfoResponseDTO paginationInfoResponseDTO = new PaginationInfoResponseDTO(
@@ -92,27 +92,27 @@ public class CustomerReviewServiceImpl implements CustomerReviewService {
     Long userSeq = customerOtherReviewsRetrieveRequestDTO.getUserSeq();
     Integer currentPage = customerOtherReviewsRetrieveRequestDTO.getPage();
 
-    int offset = (currentPage - 1) * CUSTOMER_MY_BRAND_REVIEW_LOG_SIZE;
+    int offset = (currentPage - 1) * CUSTOMER_MY_BRAND_REVIEW_LOG_PAGE_SIZE;
     int reviewCount = customerReviewMapper.getOtherReviewCount(userSeq);
     if (offset > reviewCount) {
       throw new IllegalReviewPageAccessException("해당하는 페이지에 대한 리뷰가 존재하지 않습니다.");
     }
     List<ReviewLogInfoDTO> reviewsInfo = customerReviewMapper.getOtherReviewsInfo(userSeq, offset,
-        CUSTOMER_MY_BRAND_REVIEW_LOG_SIZE);
+        CUSTOMER_MY_BRAND_REVIEW_LOG_PAGE_SIZE);
 
     int startPage =
-        ((currentPage - 1) / CUSTOMER_REVIEW_LOG_PAGE_BLOCK_SIZE)
-            * CUSTOMER_REVIEW_LOG_PAGE_BLOCK_SIZE
+        ((currentPage - 1) / CUSTOMER_MY_BRAND_REVIEW_LOG_PAGE_BLOCK_SIZE)
+            * CUSTOMER_MY_BRAND_REVIEW_LOG_PAGE_BLOCK_SIZE
             + 1;
     int endPage;
-    int pageBlockThreshold = startPage + CUSTOMER_REVIEW_LOG_PAGE_BLOCK_SIZE - 1;
-    if (reviewCount >= pageBlockThreshold * CUSTOMER_MY_BRAND_REVIEW_LOG_SIZE) {
+    int pageBlockThreshold = startPage + CUSTOMER_MY_BRAND_REVIEW_LOG_PAGE_BLOCK_SIZE - 1;
+    if (reviewCount >= pageBlockThreshold * CUSTOMER_MY_BRAND_REVIEW_LOG_PAGE_SIZE) {
       endPage = pageBlockThreshold;
     } else {
-      endPage = (int) Math.ceil((double) reviewCount / CUSTOMER_MY_BRAND_REVIEW_LOG_SIZE);
+      endPage = (int) Math.ceil((double) reviewCount / CUSTOMER_MY_BRAND_REVIEW_LOG_PAGE_SIZE);
     }
     boolean hasNext = ((currentPage < endPage) || (reviewCount
-        > pageBlockThreshold * CUSTOMER_MY_BRAND_REVIEW_LOG_SIZE));
+        > pageBlockThreshold * CUSTOMER_MY_BRAND_REVIEW_LOG_PAGE_SIZE));
     boolean hasPrevious = (currentPage > 1);
 
     PaginationInfoResponseDTO paginationInfoResponseDTO = new PaginationInfoResponseDTO(

--- a/src/main/resources/mappers/customer/customer-my-notification-map.xml
+++ b/src/main/resources/mappers/customer/customer-my-notification-map.xml
@@ -47,13 +47,14 @@
     <if test="isRead != null">
       and n.is_read = #{isRead}
     </if>
-    order by
-    n.created_at desc
-    limit #{pageSize} offset #{offset}) zzimed_me_customer
+    ) zzimed_me_customer
     inner join user u
     on zzimed_me_customer.from_user_seq = u.seq
     where
     u.code = 'CUSTOMER'
+    order by
+    zzimed_me_customer.created_at desc
+    limit #{pageSize} offset #{offset}
   </select>
 
   <select id="getZzimedMeStoresCount" resultType="java.lang.Integer">

--- a/src/main/resources/mappers/customer/customer-my-notification-map.xml
+++ b/src/main/resources/mappers/customer/customer-my-notification-map.xml
@@ -25,6 +25,7 @@
 
   <resultMap id="ZzimedMeCustomerInfoResultMap"
     type="com.nuguna.freview.customer.dto.response.ZzimedMeCustomerInfoDTO">
+    <result property="notificationSeq" column="noti_seq"/>
     <result property="customerSeq" column="from_user_seq"/>
     <result property="nickname" column="nickname"/>
     <result property="createdAt" column="created_at"/>
@@ -32,11 +33,13 @@
 
   <select id="getZzimedMeCustomers" resultMap="ZzimedMeCustomerInfoResultMap">
     select
+    zzimed_me_customer.noti_seq,
     zzimed_me_customer.from_user_seq,
     u.nickname,
     zzimed_me_customer.created_at
     from
     (select
+    n.seq as noti_seq,
     n.from_user_seq,
     n.created_at
     from
@@ -78,6 +81,7 @@
 
   <resultMap id="ZzimedMeStoreInfoResultMap"
     type="com.nuguna.freview.customer.dto.response.ZzimedMeStoreInfoDTO">
+    <result property="notificationSeq" column="noti_seq"/>
     <result property="storeSeq" column="from_user_seq"/>
     <result property="storeName" column="store_name"/>
     <result property="createdAt" column="created_at"/>
@@ -86,11 +90,13 @@
   <select id="getZzimedMeStores" resultMap="ZzimedMeStoreInfoResultMap">
     with zzimed_store as (
     select
+    noti.noti_seq,
     noti.from_user_seq,
     noti.created_at,
     u.business_number
     from
     (select
+    n.seq as noti_seq,
     n.from_user_seq,
     n.created_at
     from
@@ -110,6 +116,7 @@
     )
 
     select
+    zzimed_store.noti_seq,
     zzimed_store.from_user_seq,
     nsbi.store_name,
     zzimed_store.created_at

--- a/src/main/resources/mappers/customer/page/customer-page-map.xml
+++ b/src/main/resources/mappers/customer/page/customer-page-map.xml
@@ -35,10 +35,4 @@
     WHERE u.seq = #{customerSeq}
   </select>
 
-  <select id="getNickname" resultType="java.lang.Integer">
-    select nickname
-    from user u
-    where u.seq = #{customerSeq}
-  </select>
-
 </mapper>

--- a/src/main/resources/mappers/customer/page/customer-page-map.xml
+++ b/src/main/resources/mappers/customer/page/customer-page-map.xml
@@ -32,7 +32,13 @@
            LEFT JOIN food_type ft ON uft.food_type_seq = ft.seq
            LEFT JOIN user_tag ut ON u.seq = ut.user_seq
            LEFT JOIN tag t ON ut.tag_seq = t.seq
-    WHERE u.seq = #{userSeq}
+    WHERE u.seq = #{customerSeq}
+  </select>
+
+  <select id="getNickname" resultType="java.lang.Integer">
+    select nickname
+    from user u
+    where u.seq = #{customerSeq}
   </select>
 
 </mapper>

--- a/src/main/webapp/customer-my-notification.jsp
+++ b/src/main/webapp/customer-my-notification.jsp
@@ -1,54 +1,15 @@
-<%@ page import="com.nuguna.freview.dto.cust.brand.CustMyBrandInfoDto" %>
-<%@ page import="com.google.gson.Gson" %>
-<%@ page import="com.nuguna.freview.entity.member.Member" %>
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
+<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
 
-<%
-    CustMyBrandInfoDto brandInfo = (CustMyBrandInfoDto) request.getAttribute("brandInfo");
-    Gson gson = new Gson();
-    Member member = null;
-    int memberSeq = 0;
-    if (session.getAttribute("Member") != null) {
-        member = (Member) session.getAttribute("Member");
-        memberSeq = member.getMemberSeq();
-    }
-%>
-
+<c:set var="nickname" value="${nickname}"/>
 
 <!DOCTYPE html>
 <html lang="en">
 
 <head>
-    <style>
-      .selected-option {
-        background-color: lightgreen; /* 연초록색으로 선택된 옵션 표시 */
-      }
-    </style>
-
-    <style>
-      .form-control {
-        width: 100%;
-        height: 38px;
-        padding: 6px 12px;
-        font-size: 14px;
-        line-height: 1.42857143;
-        color: #555;
-        background-color: #fff;
-        background-image: none;
-        border: 1px solid #ccc;
-        border-radius: 4px;
-        box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
-        transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
-      }
-
-      .form-control-readonly {
-        background-color: #e9ecef;
-        opacity: 1;
-      }
-    </style>
-
+    <link rel="stylesheet" type="text/css" href="/assets/css/style-h.css"/>
     <meta charset="utf-8">
     <meta content="width=device-width, initial-scale=1.0" name="viewport">
 
@@ -76,132 +37,245 @@
 
     <!-- Template Main CSS File -->
     <link href="/assets/css/style.css" rel="stylesheet">
-    <link href="/assets/css/style-h.css" rel="stylesheet">
+    <style>
 
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
+      .form-control {
+        width: 100%;
+        height: 38px;
+        padding: 6px 12px;
+        font-size: 14px;
+        line-height: 1.42857143;
+        color: #555;
+        background-color: #fff;
+        background-image: none;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+        box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+        transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+      }
 
-    <!-- icon bootstrap -->
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
-          rel="stylesheet"
-          integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
-          crossorigin="anonymous">
+      .pagination-container {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        margin-top: 20px;
+      }
 
-    <link rel="stylesheet"
-          href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+      .table-container {
+        position: relative;
+      }
+
+      .profile-container img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover; /* 이미지의 중앙을 맞추고, 자르기 */
+        object-position: center; /* 중앙 위치 */
+      }
+
+      .bi-heart-fill {
+        color: red;
+      }
+
+      .card-body-y {
+        padding: 20px 20px;
+      }
+
+      .card-title-y > p {
+        cursor: pointer;
+      }
+
+      .pb-4 input[type="radio"] {
+        margin: 0 5px 0 10px;
+      }
+
+      .card-title-y {
+        padding: 10px 0px 5px 0;
+        font-size: 16px;
+        font-weight: 500;
+        color: #012970;
+        font-family: "Poppins", sans-serif;
+      }
+
+      .p-last {
+        margin-top: 0;
+        margin-bottom: 0.5rem;
+        font-size: 12px;
+        color: #696969;
+      }
+
+      .card-title span {
+        color: #899bbd;
+        font-size: 14px;
+        font-weight: 400;
+      }
+
+    </style>
+
+    <!-- add css-->
+    <link rel="stylesheet" href="/assets/css/style-h.css"/>
+
+    <!-- JQuery -->
+    <script src="https://code.jquery.com/jquery-3.7.1.js"></script>
+
+    <!-- Day.js -->
+    <script src="https://cdn.jsdelivr.net/npm/dayjs@1.10.7/dayjs.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.29.1/moment.min.js"></script>
 </head>
 
 <body>
 
-<!-- ======= Header ======= -->
 <header id="header" class="header fixed-top d-flex align-items-center">
     <div class="d-flex align-items-center justify-content-between">
-        <a href="/main?seq=<%=memberSeq%>&pagecode=Requester"
+        <a href="${pageContext.request.contextPath}/main?seq=${userSeq}&pagecode=Requester"
            class="logo d-flex align-items-center">
             <img src="/assets/img/logo/logo-vertical.png" alt="">
             <span class="d-none d-lg-block">FReview</span>
         </a>
         <i class="bi bi-list toggle-sidebar-btn"></i>
-    </div><!-- End Logo -->
+    </div>
 
-    <!-- 우측 상단 닉네임&프로필 사진 -->
     <nav class="header-nav ms-auto">
         <ul class="d-flex align-items-center">
             <li class="nav-item dropdown pe-3">
                 <a class="nav-link nav-profile d-flex align-items-center pe-0" href="#">
-                    <img src="/assets/img/basic/basic-profile-img.png" alt="Profile"
-                         class="rounded-circle">
+
+                    <img src="/user/${userSeq}/profile"
+                         alt="Profile"
+                         class="rounded-circle profile-img"
+                         style="margin-right: 5px;">
                     <span id="nickname-holder-head"
-                          class="d-none d-md-block"><%=member.getNickname()%></span>
-                </a><!-- End Profile Iamge Icon -->
-            </li><!-- End Profile Nav -->
+                          class="d-none d-md-block"
+                          style="font-size : 18px;">${nickname}</span>
+                </a>
+            </li>
         </ul>
-    </nav><!-- End Icons Navigation -->
-</header><!-- End Header -->
+    </nav>
+</header>
+
 
 <!-- ======= Sidebar ======= -->
 <aside id="sidebar" class="sidebar">
     <ul class="sidebar-nav" id="sidebar-nav">
         <li class="nav-item">
-            <a class="nav-link collapsed" href="${pageContext.request.contextPath}/my-info">
-                <i class="bi bi-person-lines-fill"></i><span>브랜딩</span>
+            <a class="nav-link collapsed"
+               href="/my/brand-info?userSeq=${userSeq}">
+                <i class="bi bi-grid"></i>
+                <span>브랜딩</span>
             </a>
-        </li><!-- End Components Nav -->
+        </li><!-- End Dashboard Nav -->
 
         <li class="nav-item">
             <a class="nav-link collapsed"
-               href="${pageContext.request.contextPath}/my-activity">
-                <i class="bi bi-layout-text-window-reverse"></i>
-                <span>활동</span>
-            </a>
-        </li><!-- End Profile Page Nav -->
-
-        <li class="nav-item">
-            <a class="nav-link" data-bs-target="#components-nav" href="#">
-                <i class="bi bi-envelope"></i>
-                <span>알림</span>
-            </a>
-        </li><!-- End F.A.Q Page Nav -->
-
-        <li class="nav-item">
-            <a class="nav-link collapsed"
-               href="${pageContext.request.contextPath}/my-personal-info">
-                <i class="ri-edit-box-line"></i>
-                <span>개인정보수정</span>
+               href="${pageContext.request.contextPath}/my/experience?userSeq=${userSeq}">
+                <i class="bi bi-card-checklist"></i>
+                <span>체험</span>
             </a>
         </li>
+        <!-- End Profile Page Nav -->
+
+        <li class="nav-item">
+            <a class="nav-link collapsed "
+               href="${pageContext.request.contextPath}/my/activity?userSeq=${userSeq}">
+                <i class="bi bi-bell"></i>
+                <span>활동</span>
+            </a>
+        </li>
+        <!-- End Profile Page Nav -->
+
+        <li class="nav-item">
+            <a class="nav-link "
+               href="${pageContext.request.contextPath}/my/notification?userSeq=${userSeq}">
+                <i class="bi bi-card-checklist"></i>
+                <span>알림</span>
+            </a>
+        </li>
+        <!-- End Profile Page Nav -->
+
+        <li class="nav-item">
+            <a class="nav-link collapsed"
+               href="${pageContext.request.contextPath}/my/personal-info?userSeq=${userSeq}">
+                <i class="bi bi-person"></i>
+                <span>개인정보수정</span>
+            </a>
+        </li><!-- End Register Page Nav -->
     </ul>
 </aside><!-- End Sidebar-->
 
 <main id="main" class="main">
-
-    <div class="pagetitle">
-        <h1>알림</h1>
-    </div><!-- End Page Title -->
-
     <section class="section profile">
         <div class="row">
             <div class="col-xl-12">
                 <div class="card">
-                    <div class="card-body pt-3">
+                    <div class="card-body">
                         <!-- Bordered Tabs -->
-                        <ul class="nav nav-tabs nav-tabs-bordered">
-                            <li class="nav-item">
-                                <button class="nav-link active" data-bs-toggle="tab"
-                                        data-bs-target="#receivedBtn" id="sendRequest">
-                                    보낸 요청
+                        <ul class="nav nav-tabs nav-tabs-bordered pt-4" id="borderedTab"
+                            role="tablist">
+                            <li class="nav-item" role="presentation">
+                                <button class="nav-link active" id="zzimed-me-stores-tab"
+                                        data-bs-toggle="tab"
+                                        data-bs-target="#zzimed-me-stores" type="button" role="tab"
+                                        aria-controls="like" aria-selected="true">나를 찜한 스토어
                                 </button>
                             </li>
-                            <li class="nav-item">
-                                <button class="nav-link" data-bs-toggle="tab"
-                                        data-bs-target="#requestBtn" id="receivedRequest">
-                                    받은 요청
-                                </button>
-                            </li>
-                            <li class="nav-item">
-                                <button class="nav-link" data-bs-toggle="tab"
-                                        data-bs-target="#requestBtn" id="acceptedRequest">
-                                    수락 요청
+                            <li class="nav-item" role="presentation">
+                                <button class="nav-link" id="zzimed-me-customers-tab"
+                                        data-bs-toggle="tab"
+                                        data-bs-target="#zzimed-me-customers" type="button"
+                                        role="tab"
+                                        aria-controls="zzim" aria-selected="false">나를 찜한 체험단
                                 </button>
                             </li>
                         </ul>
-                        <div class="tab-content pt-1">
-                            <div class="tab-pane show fade active profile-edit pt-6"
-                                 id="receivedBtn">
 
+                        <div class="tab-content pt-4" id="borderedTabContent">
+                            <!-- 나를 찜한 스토어 -->
+                            <div class="tab-pane fade show active" id="zzimed-me-stores"
+                                 role="tabpanel"
+                                 aria-labelledby="zzim-me-stores-tab">
+                                <div>
+                                    <div class="pb-4">
+                                        <input type="radio" id="zzimed-me-stores-noti-read"
+                                               name="isReadStores"
+                                               value="true" checked/> 읽음
+                                        <input type="radio" id="zzimed-me-stores-noti-not-read"
+                                               name="isReadStores"
+                                               value="false"/> 안읽음
+                                    </div>
+                                </div>
+                                <div id="zzimedMeStoresList" class="row">
+                                    <!-- 나를 찜한 스토어 리스트가 렌더링 -->
+                                </div>
+                                <!-- 페이지네이션 버튼 -->
+                                <div class="pagination-container"
+                                     id="zzimed-me-stores-pagination"></div>
+                            </div>
+
+                            <!-- 나를 찜한 체험단 -->
+                            <div class="tab-pane fade" id="zzimed-me-customers" role="tabpanel"
+                                 aria-labelledby="zzim-me-customers-tab">
+                                <div>
+                                    <div class="pb-4">
+                                        <input type="radio" id="zzimed-me-customers-noti-read"
+                                               name="isReadCustomers"
+                                               value="true" checked/> 읽음
+                                        <input type="radio" id="zzimed-me-customers-noti-not-read"
+                                               name="isReadCustomers"
+                                               value="false"/> 안읽음
+                                    </div>
+                                </div>
+                                <div id="zzimedMeCustomersList" class="row"></div>
+                                <!-- 페이지네이션 버튼 -->
+                                <div class="pagination-container"
+                                     id="zzimed-me-customers-pagination"></div>
                             </div>
                         </div>
-                        <div class="tab-content pt-2">
-                            <div class="tab-pane fade active pt-6" id="requestBtn">
-
-                            </div>
-                        </div>
-                        <!-- End Bordered Tabs -->
                     </div>
                 </div>
             </div>
         </div>
     </section>
-</main><!-- End #main -->
+</main>
+
 
 <!-- ======= Footer ======= -->
 <footer id="footer" class="footer">
@@ -215,12 +289,6 @@
 
 <a href="#" class="back-to-top d-flex align-items-center justify-content-center"><i
         class="bi bi-arrow-up-short"></i></a>
-<!-- jquery  -->
-
-<!-- icon bootstrap -->
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
-        integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
-        crossorigin="anonymous"></script>
 
 <!-- Vendor JS Files -->
 <script src="/assets/vendor/apexcharts/apexcharts.min.js"></script>
@@ -231,9 +299,205 @@
 <script src="/assets/vendor/simple-datatables/simple-datatables.js"></script>
 <script src="/assets/vendor/tinymce/tinymce.min.js"></script>
 <script src="/assets/vendor/php-email-form/validate.js"></script>
-
 <!-- Template Main JS File -->
 <script src="/assets/js/main.js"></script>
+<script>
+  $(document).ready(function () {
+    let userSeq = '${userSeq}';
+    let currentPage = 1;
+
+    // 페이지 최초 로드 시 나를 찜한 스토어 리스트 전송
+    sendZZimedMeStoreList(1);
+
+    // 나를 찜한 스토어 리스트 전송 함수
+    function sendZZimedMeStoreList(page) {
+      let isRead = $("input[name='isReadStores']:checked").val() === 'true';
+      let sendData = {
+        'userSeq': userSeq,
+        'isRead': isRead,
+        'targetPage': page
+      };
+      $.ajax({
+        type: "GET",
+        url: "/api/customer/my/notification/zzimed-me-stores",
+        data: $.param(sendData),
+        contentType: "application/x-www-form-urlencoded",
+        dataType: "json",
+        error: function (response) {
+          console.error("[ERROR] 나를 찜한 스토어 리스트 불러오기 실패하였습니다. 다시 시도해주세요.");
+        },
+        success: function (response) {
+          let {paginationInfo, zzimedMeStoreInfos} = response;
+          renderZzimStoreList(zzimedMeStoreInfos);
+          initializePagination(paginationInfo, 'zzimed-me-stores');
+        }
+      });
+    }
+
+    // 나를 찜한 체험단 리스트 전송 함수
+    function sendZzimCustomerList(page) {
+      let isRead = $("input[name='isReadCustomers']:checked").val() === 'true';
+      let sendData = {
+        'userSeq': userSeq,
+        'isRead': isRead,
+        'targetPage': page
+      };
+      $.ajax({
+        type: "GET",
+        url: "/api/customer/my/notification/zzimed-me-customers",
+        data: $.param(sendData),
+        contentType: "application/x-www-form-urlencoded",
+        dataType: "json",
+        error: function (response) {
+          console.error("[ERROR] 나를 찜한 체험단 리스트 불러오기 실패하였습니다. 다시 시도해주세요.");
+        },
+        success: function (response) {
+          let {paginationInfo, zzimedMeCustomerInfos} = response;
+          renderZzimCustomerList(zzimedMeCustomerInfos);
+          initializePagination(paginationInfo, 'zzimed-me-customers');
+        }
+      });
+    }
+
+    // 나를 찜한 스토어 리스트 렌더링 함수
+    function renderZzimStoreList(zzimedMeStoreInfos) {
+      let htmlStr = "";
+      $.map(zzimedMeStoreInfos, function (item) {
+        htmlStr += "<div class='card'>";
+        htmlStr += "<div class='card-body-y mt-2'>";
+        htmlStr += "<p><a href='/brand/" + item.storeSeq + "?fromUserSeq=${userSeq}" + "'>"
+            + item.storeName + "</a>님이 나를 찜하였습니다.</p>";
+        htmlStr += "<p class='p-last'>" + item.createdAt.year + "년 " + item.createdAt.monthValue
+            + "월 " + item.createdAt.dayOfMonth + "일</p>";
+        if (!($("input[name='isReadStores']:checked").val() === 'true')) {
+          htmlStr += "<button class='btn btn-primary mark-as-read' data-notification-seq='"
+              + item.notificationSeq + "'>읽음확인</button>";
+        }
+        htmlStr += "</div>";
+        htmlStr += "</div>";
+      });
+      $("#zzimedMeStoresList").html(htmlStr);
+    }
+
+    // 나를 찜한 체험단 리스트 렌더링 함수
+    function renderZzimCustomerList(zzimedMeCustomerInfos) {
+      let htmlStr = "";
+      $.map(zzimedMeCustomerInfos, function (item) {
+        htmlStr += "<div class='card'>";
+        htmlStr += "<div class='card-body-y mt-2'>";
+        htmlStr += "<p><a href='/brand/" + item.customerSeq + "?fromUserSeq=${userSeq}" + "'>"
+            + item.nickname + "</a>님이 나를 찜하였습니다.</p>";
+        htmlStr += "<p class='p-last'>" + item.createdAt.year + "년 " + item.createdAt.monthValue
+            + "월 " + item.createdAt.dayOfMonth + "일</p>";
+        if (!($("input[name='isReadCustomers']:checked").val() === 'true')) {
+          htmlStr += "<button class='btn btn-primary mark-as-read' data-notification-seq='"
+              + item.notificationSeq + "'>읽음확인</button>";
+        }
+        htmlStr += "</div>";
+        htmlStr += "</div>";
+      });
+      $("#zzimedMeCustomersList").html(htmlStr);
+    }
+
+    // 페이지 네이션 처리
+    function initializePagination(paginationInfo, page) {
+      let currentPage = paginationInfo.currentPage;
+      let startPage = paginationInfo.startPage;
+      let endPage = paginationInfo.endPage;
+      let hasNext = paginationInfo.hasNext;
+      let hasPrevious = paginationInfo.hasPrevious;
+
+      let paginationContainer = $("#" + page + "-pagination");
+
+      let paginationHTML = '';
+      if (hasPrevious) {
+        paginationHTML += '<button id="prev-block-button" class="btn btn-primary edit-btn" data-page="'
+            + (parseInt(currentPage) - 1) + '">&lt;</button>';
+      }
+
+      for (let i = startPage; i <= endPage; i++) {
+        paginationHTML += '<button class="btn ' + (i === currentPage ? 'btn-secondary'
+            : 'btn-primary') + ' edit-btn" data-page="' + i + '">' + i + '</button>';
+      }
+
+      if (hasNext) {
+        paginationHTML += '<button id="next-block-button" class="btn btn-primary edit-btn" data-page="'
+            + (parseInt(currentPage) + 1) + '">&gt;</button>';
+      }
+
+      paginationContainer.html(paginationHTML);
+    }
+
+    // 탭 클릭 시 해당 리스트 전송
+    $("#zzimed-me-stores-tab").on('click', function () {
+      $("#zzimed-me-stores-noti-read").prop("checked", true);
+      sendZZimedMeStoreList(1);
+    });
+
+    $("#zzimed-me-customers-tab").on('click', function () {
+      $("#zzimed-me-customers-noti-read").prop("checked", true);
+      sendZzimCustomerList(1);
+    });
+
+    // 읽음/안읽음 필터 변경 시 리스트 전송
+    $("input[name='isReadStores']").on('change', function () {
+      sendZZimedMeStoreList(1);
+    });
+
+    $("input[name='isReadCustomers']").on('change', function () {
+      sendZzimCustomerList(1);
+    });
+
+    // 페이지 버튼 클릭 이벤트
+    $(document).on("click", ".btn.edit-btn", function (e) {
+      let pageNumber = parseInt($(this).data("page"));
+      if (pageNumber > 0) {
+        handlePageChange(
+            $(this).closest(".pagination-container").attr("id").replace("-pagination", ""),
+            pageNumber);
+      }
+    });
+
+    // 읽음확인 버튼 클릭 이벤트
+    $(document).on("click", ".mark-as-read", function () {
+      let notificationSeq = $(this).data("notification-seq");
+      markNotificationAsRead(userSeq, notificationSeq);
+    });
+
+    // 알림 읽음 처리 함수
+    function markNotificationAsRead(userSeq, notificationSeq) {
+      $.ajax({
+        type: "POST",
+        url: "/api/customer/my/notification/" + notificationSeq,
+        data: $.param({userSeq: userSeq}),
+        contentType: "application/x-www-form-urlencoded",
+        dataType: "text",
+        success: function (response) {
+          alert("알림 변경 성공");
+          // 현재 활성 탭에 따라 페이지 새로고침
+          if ($("#zzimed-me-stores-tab").hasClass("active")) {
+            sendZZimedMeStoreList(currentPage);
+          } else if ($("#zzimed-me-customers-tab").hasClass("active")) {
+            sendZzimCustomerList(currentPage);
+          }
+        },
+        error: function (response) {
+          console.error("[ERROR] 알림을 읽음으로 표시하는 데 실패했습니다. 다시 시도해주세요.");
+        }
+      });
+    }
+
+    // 페이지 변경 핸들러
+    function handlePageChange(tab, page) {
+      currentPage = page;
+      if (tab === 'zzimed-me-stores') {
+        sendZZimedMeStoreList(page);
+      } else if (tab === 'zzimed-me-customers') {
+        sendZzimCustomerList(page);
+      }
+    }
+  });
+</script>
 
 
 </body>

--- a/src/main/webapp/customer-my-notification.jsp
+++ b/src/main/webapp/customer-my-notification.jsp
@@ -473,7 +473,7 @@
         contentType: "application/x-www-form-urlencoded",
         dataType: "text",
         success: function (response) {
-          alert("알림 변경 성공");
+          alert("해당 알림을 읽음처리 했습니다.");
           // 현재 활성 탭에 따라 페이지 새로고침
           if ($("#zzimed-me-stores-tab").hasClass("active")) {
             sendZZimedMeStoreList(currentPage);


### PR DESCRIPTION
## [ 체험단 > MY > 알림 페이지 ]

### 1. 나를 찜한 스토어 알림 ( 읽음 )
<img width="1454" alt="스크린샷 2024-08-06 오후 6 27 24" src="https://github.com/user-attachments/assets/21af05e5-81c7-465d-b649-a94499f46b34">

### 2. 나를 찜한 스토어 알림 ( 안읽음 )
<img width="1467" alt="스크린샷 2024-08-06 오후 6 27 44" src="https://github.com/user-attachments/assets/437f0a34-b67d-480a-831b-0c9cfe78d3dd">

### 3. 스토어명 클릭 시, 스토어 브랜딩 페이지로 이동
- a href로 구현하여 사진은 생략합니다.

### 4. 나를 찜한 체험단 알림 ( 읽음 )
<img width="1463" alt="스크린샷 2024-08-06 오후 6 28 52" src="https://github.com/user-attachments/assets/fdc87a89-c262-4b87-8cc8-2579e4b3a304">

#### 페이지네이션또한 가능합니다.

### 5. 나를 찜한 스토어 알림 ( 안읽음 )

<img width="1470" alt="스크린샷 2024-08-06 오후 6 29 31" src="https://github.com/user-attachments/assets/0918f037-0fd8-4fd1-9eda-95c16f34d285">

### 6. 안읽은 알림에 대해 읽음 처리 가능
- 읽음 확인 후 다시 해당 페이지로 렌더링 ( 현재 2페이지면, 2페이지를 다시 ajax로 렌더링해서 뿌려줌 )

<img width="1469" alt="스크린샷 2024-08-06 오후 6 35 45" src="https://github.com/user-attachments/assets/d31a64e2-0871-4cc9-a113-3368b7eb332a">

<img width="1454" alt="스크린샷 2024-08-06 오후 6 31 46" src="https://github.com/user-attachments/assets/005617b3-9692-4af7-9852-caa1f08ef24d">