### PR TITLE
[feat-customer] 체험단 > MY > 체험 페이지 뷰 - API 연동 ( 체험 페이지 구현 완료 )

### DIFF
--- a/src/main/java/com/nuguna/freview/customer/controller/page/CustomerMyPageController.java
+++ b/src/main/java/com/nuguna/freview/customer/controller/page/CustomerMyPageController.java
@@ -41,6 +41,7 @@ public class CustomerMyPageController {
   public String customerMyExperiencePage(@RequestParam Long userSeq, Model model) {
     String nickname = customerUtilService.getUserNickname(userSeq);
     model.addAttribute("nickname", nickname);
+    model.addAttribute("userSeq", userSeq);
     return "customer-my-experience-info";
   }
 

--- a/src/main/resources/mappers/customer/customer-my-experience-map.xml
+++ b/src/main/resources/mappers/customer/customer-my-experience-map.xml
@@ -95,6 +95,7 @@
     from experience e
     where from_user_seq = #{userSeq}
       and status in ('ACCEPTED', 'NOSHOW', 'DONE')
+      and e.visit_date is not null
   </select>
 
   <resultMap id="MyAcceptedApplyInfoResultMap"
@@ -119,7 +120,8 @@
                  e.status
           from experience e
           where from_user_seq = #{userSeq}
-            and e.status in ('ACCEPTED', 'NOSHOW', 'DONE')) my_accepted_applied_experiences
+            and e.status in ('ACCEPTED', 'NOSHOW', 'DONE')
+            and e.visit_date is not null) my_accepted_applied_experiences
            inner join
          user u
          on
@@ -137,6 +139,7 @@
     from experience e
     where to_user_seq = #{userSeq}
       and status in ('ACCEPTED', 'NOSHOW', 'DONE')
+      and e.visit_date is not null
   </select>
 
   <resultMap id="AcceptedProposalToMeInfoResultMap"
@@ -162,7 +165,8 @@
                  e.created_at
           from experience e
           where to_user_seq = #{userSeq}
-            and e.status in ('ACCEPTED', 'NOSHOW', 'DONE')) accepted_proposal_to_me_experiences
+            and e.status in ('ACCEPTED', 'NOSHOW', 'DONE')
+            and e.visit_date is not null) accepted_proposal_to_me_experiences
            inner join
          user u
          on

--- a/src/main/webapp/WEB-INF/spring/servlet-context.xml
+++ b/src/main/webapp/WEB-INF/spring/servlet-context.xml
@@ -4,16 +4,15 @@
   xmlns="http://www.springframework.org/schema/beans"
   xmlns:mvc="http://www.springframework.org/schema/mvc"
   xmlns:context="http://www.springframework.org/schema/context"
-  xmlns:tx="http://www.springframework.org/schema/tx"
-  xmlns:task="http://www.springframework.org/schema/task"
+
+
   xsi:schemaLocation="http://www.springframework.org/schema/mvc
-	http://www.springframework.org/schema/mvc/spring-mvc.xsd
-	http://www.springframework.org/schema/beans
-	http://www.springframework.org/schema/beans/spring-beans.xsd
-	http://www.springframework.org/schema/context
-	http://www.springframework.org/schema/context/spring-context.xsd
-	http://www.springframework.org/schema/tx
-	http://www.springframework.org/schema/tx/spring-tx.xsd http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task.xsd">
+   http://www.springframework.org/schema/mvc/spring-mvc.xsd
+   http://www.springframework.org/schema/beans
+   http://www.springframework.org/schema/beans/spring-beans.xsd
+   http://www.springframework.org/schema/context
+   http://www.springframework.org/schema/context/spring-context.xsd">
+
   <!--
   MariaDB ID/PW (src/main/resources/maria.properties)
   MyBatis 매퍼파일 (src/main/resources/mappers/ *-map.xml)
@@ -34,98 +33,14 @@
   <!--<mvc:resources mapping="/resources/**" location="/resources/"/>-->
   <mvc:resources mapping="/assets/**" location="/assets/"/>
 
-  <!-- Property Placeholder 설정 -->
-  <context:property-placeholder
-    location="classpath:maria.properties,classpath:sendEmail.properties"/>
-
   <!-- =============================== /  +  @Controllers 리턴값 + .jsp     -->
   <bean class="org.springframework.web.servlet.view.InternalResourceViewResolver">
     <property name="prefix" value="/"/>
     <property name="suffix" value=".jsp"/>
   </bean>
 
-  <!-- ################################################################################  -->
-  <!-- =============================== datasource : 프로퍼티 파일을 사용한 형태 -->
-
-  <bean id="dataSource" class="org.apache.commons.dbcp.BasicDataSource" destroy-method="close">
-    <property name="driverClassName" value="${driver-class-name}"/>
-    <property name="url" value="${db-url}"/>
-    <property name="username" value="${db-username}"/>
-    <property name="password" value="${db-password}"/>
-  </bean>
-  <!-- ===================================================
-     트랜잭션 관련 설정
-     - annotation-driven :: txManager(Datasource) - @Transactional
-   ======================================================= -->
-  <!-- txManager [ DataSource ... sqlSession ] 관리를 위한 매니저 설정 -->
-  <bean id="txManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
-    <property name="dataSource" ref="logDataSource"/>
-  </bean>
-
-  <!-- annotation 기반 설정 시  @Transactional이 붙은 메서드만 관리  -->
-  <tx:annotation-driven transaction-manager="txManager"/>
-
-  <!-- ################################################################################  -->
-  <!-- =============================== DBCPool + MyBatis
-       [ DataSource == SqlSessionFactoryBean - *SqlSessionTemplate -  sqlSession ]
-                                            (datasource 에서 가져온 session 관리)
-  -->
-  <bean id="sqlSessionFactory" class="org.mybatis.spring.SqlSessionFactoryBean">
-    <property name="dataSource" ref="logDataSource"/>
-    <property name="mapperLocations" value="classpath:mappers/**/*-map.xml"/>
-    <property name="configLocation" value="classpath:mybatis-context.xml"/>
-  </bean>
-  <bean id="sqlSession" class="org.mybatis.spring.SqlSessionTemplate">
-    <constructor-arg index="0" ref="sqlSessionFactory"/>
-  </bean>
-
-  <!-- =============================== MYBATIS 콘솔 로그 출력 : log4jdbc-remix.jar -->
-  <bean id="logDataSource" class="net.sf.log4jdbc.Log4jdbcProxyDataSource">
-    <constructor-arg ref="dataSource"/>
-    <property name="logFormatter">
-      <bean class="net.sf.log4jdbc.tools.Log4JdbcCustomFormatter">
-        <property name="loggingType" value="MULTI_LINE"/>
-        <property name="sqlPrefix" value=""/>
-      </bean>
-    </property>
-  </bean>
-
-  <!-- =============================== MyBatis + Mapper인터페이스
-     MapperScannerConfigurer : @Mapper 찾기 + sqlSessionFactory  -->
-  <bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
-    <property name="basePackage" value="com.nuguna.freview.admin.mapper"/>
-    <property name="sqlSessionFactoryBeanName" value="sqlSessionFactory"/>
-  </bean>
-
-  <bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
-    <property name="basePackage" value="com.nuguna.freview.common.mapper"/>
-    <property name="sqlSessionFactoryBeanName" value="sqlSessionFactory"/>
-  </bean>
-
-  <bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
-    <property name="basePackage" value="com.nuguna.freview.customer.mapper"/>
-    <property name="sqlSessionFactoryBeanName" value="sqlSessionFactory"/>
-  </bean>
-
-  <bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
-    <property name="basePackage" value="com.nuguna.freview.store.mapper"/>
-    <property name="sqlSessionFactoryBeanName" value="sqlSessionFactory"/>
-  </bean>
-
-
-  <!-- ################################################################################  -->
-  <!-- =============================== datasource : 프로퍼티 파일을 사용한 형태 -->
-
-  <bean id="sendEmail" class="com.nuguna.freview.global.util.SendMailUtil">
-    <constructor-arg name="ENCODING" value="${gmail-encoding}"/>
-    <constructor-arg name="PORT" value="${gmail-port}"/>
-    <constructor-arg name="SMTPHOST" value="${gmail-smtphost}"/>
-    <constructor-arg name="userName" value="${gmail-usermail}"/>
-    <constructor-arg name="password" value="${gmail-password}"/>
-  </bean>
-
-  <!-- =============================== scheduler 사용 -->
-  <task:scheduler id="jobScheduler" pool-size="10"/>
-  <task:annotation-driven scheduler="jobScheduler"/>
+  <!-- Property Placeholder 설정 -->
+  <context:property-placeholder
+    location="classpath:maria.properties,classpath:sendEmail.properties,classpath:scheduler.properties"/>
 
 </beans>

--- a/src/main/webapp/customer-my-experience-info.jsp
+++ b/src/main/webapp/customer-my-experience-info.jsp
@@ -497,9 +497,9 @@
         if (item.status === 'ACCEPTED') {
           htmlStr += "<span style='color:green'>수락됨</span>";
         } else if (item.status === 'NOSHOW') {
-          htmlStr += "<span style='color:blue'>완료됨</span>";
-        } else if (item.status === 'DONE') {
           htmlStr += "<span style='color:mediumvioletred'>노쇼</span>";
+        } else if (item.status === 'DONE') {
+          htmlStr += "<span style='color:blue'>완료됨</span>";
         }
         htmlStr += "</p>";
         htmlStr += "<p>체험 날짜: " + item.experienceDate.year + "년 " + item.experienceDate.monthValue
@@ -519,13 +519,14 @@
         htmlStr += "<div class='card-body-y mt-2'>";
         htmlStr += "<p><a href='/brand/" + item.storeSeq + "'>" + item.storeName
             + "</a>님의 <span style='color:chocolate'>체험 제안</span>을 수락했습니다.</p>";
+        htmlStr += "<p>제안 내용: " + item.proposalDetails + "</p>";
         htmlStr += "<p>진행 현황: ";
         if (item.status === 'ACCEPTED') {
           htmlStr += "<span style='color:green'>수락됨</span>";
         } else if (item.status === 'NOSHOW') {
-          htmlStr += "<span style='color:blue'>완료됨</span>";
-        } else if (item.status === 'DONE') {
           htmlStr += "<span style='color:mediumvioletred'>노쇼</span>";
+        } else if (item.status === 'DONE') {
+          htmlStr += "<span style='color:blue'>완료됨</span>";
         }
         htmlStr += "</p>";
         htmlStr += "<p>체험 날짜: " + item.experienceDate.year + "년 " + item.experienceDate.monthValue

--- a/src/main/webapp/customer-my-experience-info.jsp
+++ b/src/main/webapp/customer-my-experience-info.jsp
@@ -1,9 +1,420 @@
-<%@ page contentType="text/html;charset=UTF-8" language="java" %>
-<html>
+<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
+<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+
+<c:set var="nickname" value="${nickname}"/>
+
+<!DOCTYPE html>
+<html lang="en">
+
 <head>
+    <link rel="stylesheet" type="text/css" href="/assets/css/style-h.css"/>
+    <meta charset="utf-8">
+    <meta content="width=device-width, initial-scale=1.0" name="viewport">
+
     <title>FReview</title>
+    <meta content="" name="description">
+    <meta content="" name="keywords">
+
+    <!-- Favicons -->
+    <link href="/assets/img/favicon.png" rel="icon">
+    <link href="/assets/img/apple-touch-icon.png" rel="apple-touch-icon">
+
+    <!-- Google Fonts -->
+    <link href="https://fonts.gstatic.com" rel="preconnect">
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,300i,400,400i,600,600i,700,700i|Nunito:300,300i,400,400i,600,600i,700,700i|Poppins:300,300i,400,400i,500,500i,600,600i,700,700i"
+          rel="stylesheet">
+
+    <!-- Vendor CSS Files -->
+    <link href="/assets/vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/assets/vendor/bootstrap-icons/bootstrap-icons.css" rel="stylesheet">
+    <link href="/assets/vendor/boxicons/css/boxicons.min.css" rel="stylesheet">
+    <link href="/assets/vendor/quill/quill.snow.css" rel="stylesheet">
+    <link href="/assets/vendor/quill/quill.bubble.css" rel="stylesheet">
+    <link href="/assets/vendor/remixicon/remixicon.css" rel="stylesheet">
+    <link href="/assets/vendor/simple-datatables/style.css" rel="stylesheet">
+
+    <!-- Template Main CSS File -->
+    <link href="/assets/css/style.css" rel="stylesheet">
+    <style>
+
+      .form-control {
+        width: 100%;
+        height: 38px;
+        padding: 6px 12px;
+        font-size: 14px;
+        line-height: 1.42857143;
+        color: #555;
+        background-color: #fff;
+        background-image: none;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+        box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+        transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+      }
+
+      .pagination-container {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        margin-top: 20px;
+      }
+
+      .table-container {
+        position: relative;
+      }
+
+      .profile-container img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover; /* 이미지의 중앙을 맞추고, 자르기 */
+        object-position: center; /* 중앙 위치 */
+      }
+
+      .bi-heart-fill {
+        color: red;
+      }
+
+      .card-body-y {
+        padding: 20px 20px;
+      }
+
+      .card-title-y > p {
+        cursor: pointer;
+      }
+
+      .pb-4 input[type="radio"] {
+        margin: 0 5px 0 10px;
+      }
+
+      .card-title-y {
+        padding: 10px 0px 5px 0;
+        font-size: 16px;
+        font-weight: 500;
+        color: #012970;
+        font-family: "Poppins", sans-serif;
+      }
+
+      .p-last {
+        margin-top: 0;
+        margin-bottom: 0.5rem;
+        font-size: 12px;
+        color: #696969;
+      }
+
+      .card-title span {
+        color: #899bbd;
+        font-size: 14px;
+        font-weight: 400;
+      }
+
+    </style>
+
+    <!-- add css-->
+    <link rel="stylesheet" href="/assets/css/style-h.css"/>
+
+    <!-- JQuery -->
+    <script src="https://code.jquery.com/jquery-3.7.1.js"></script>
+
+    <!-- Day.js -->
+    <script src="https://cdn.jsdelivr.net/npm/dayjs@1.10.7/dayjs.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.29.1/moment.min.js"></script>
 </head>
+
 <body>
 
+<header id="header" class="header fixed-top d-flex align-items-center">
+    <div class="d-flex align-items-center justify-content-between">
+        <a href="${pageContext.request.contextPath}/main?seq=${userSeq}&pagecode=Requester"
+           class="logo d-flex align-items-center">
+            <img src="/assets/img/logo/logo-vertical.png" alt="">
+            <span class="d-none d-lg-block">FReview</span>
+        </a>
+        <i class="bi bi-list toggle-sidebar-btn"></i>
+    </div>
+
+    <nav class="header-nav ms-auto">
+        <ul class="d-flex align-items-center">
+            <li class="nav-item dropdown pe-3">
+                <a class="nav-link nav-profile d-flex align-items-center pe-0" href="#">
+
+                    <img src="/user/${userSeq}/profile"
+                         alt="Profile"
+                         class="rounded-circle profile-img"
+                         style="margin-right: 5px;">
+                    <span id="nickname-holder-head"
+                          class="d-none d-md-block"
+                          style="font-size : 18px;">${nickname}</span>
+                </a>
+            </li>
+        </ul>
+    </nav>
+</header>
+
+
+<!-- ======= Sidebar ======= -->
+<aside id="sidebar" class="sidebar">
+    <ul class="sidebar-nav" id="sidebar-nav">
+        <li class="nav-item">
+            <a class="nav-link collapsed"
+               href="/my/brand-info?userSeq=${userSeq}">
+                <i class="bi bi-grid"></i>
+                <span>브랜딩</span>
+            </a>
+        </li><!-- End Dashboard Nav -->
+
+        <li class="nav-item">
+            <a class="nav-link"
+               href="${pageContext.request.contextPath}/my/experience?userSeq=${userSeq}">
+                <i class="bi bi-card-checklist"></i>
+                <span>체험</span>
+            </a>
+        </li>
+        <!-- End Profile Page Nav -->
+
+        <li class="nav-item">
+            <a class="nav-link collapsed "
+               href="${pageContext.request.contextPath}/my/activity?userSeq=${userSeq}">
+                <i class="bi bi-bell"></i>
+                <span>활동</span>
+            </a>
+        </li>
+        <!-- End Profile Page Nav -->
+
+        <li class="nav-item">
+            <a class="nav-link collapsed"
+               href="${pageContext.request.contextPath}/my/notification?userSeq=${userSeq}">
+                <i class="bi bi-card-checklist"></i>
+                <span>알림</span>
+            </a>
+        </li>
+        <!-- End Profile Page Nav -->
+
+        <li class="nav-item">
+            <a class="nav-link collapsed"
+               href="${pageContext.request.contextPath}/my/personal-info?userSeq=${userSeq}">
+                <i class="bi bi-person"></i>
+                <span>개인정보수정</span>
+            </a>
+        </li><!-- End Register Page Nav -->
+    </ul>
+</aside><!-- End Sidebar-->
+
+<main id="main" class="main">
+    <section class="section profile">
+        <div class="row">
+            <div class="col-xl-12">
+                <div class="card">
+                    <div class="card-body">
+                        <!-- Bordered Tabs -->
+                        <ul class="nav nav-tabs nav-tabs-bordered pt-4" id="borderedTab"
+                            role="tablist">
+                            <li class="nav-item" role="presentation">
+                                <button class="nav-link active" id="my-applied-experience-tab"
+                                        data-bs-toggle="tab" data-bs-target="#my-applied-experience"
+                                        type="button" role="tab" aria-selected="true">지원 리스트
+                                </button>
+                            </li>
+                            <li class="nav-item" role="presentation">
+                                <button class="nav-link" id="proposal-to-me-experience-tab"
+                                        data-bs-toggle="tab"
+                                        data-bs-target="#proposal-to-me-experience" type="button"
+                                        role="tab" aria-selected="false">제안 리스트
+                                </button>
+                            </li>
+                            <li class="nav-item" role="presentation">
+                                <button class="nav-link" id="my-accepted-experience-tab"
+                                        data-bs-toggle="tab"
+                                        data-bs-target="#my-accepted-experience" type="button"
+                                        role="tab" aria-selected="false">수락 리스트
+                                </button>
+                            </li>
+                        </ul>
+
+                        <div class="tab-content pt-4" id="borderedTabContent">
+                            <!-- 나의 모집 지원 리스트 -->
+                            <div class="tab-pane fade show active" id="my-applied-experience"
+                                 role="tabpanel" aria-labelledby="my-applied-experience-tab">
+                                <div id="myAppliedExperienceList" class="row">
+                                    <!-- 내가 지원한 체험 리스트가 렌더링 -->
+                                </div>
+                                <!-- 페이지네이션 버튼 -->
+                                <div class="pagination-container"
+                                     id="my-applied-experience-pagination"></div>
+                            </div>
+
+                            <!-- 나에게 온 체험 제안 리스트 -->
+                            <div class="tab-pane fade" id="proposal-to-me-experience"
+                                 role="tabpanel" aria-labelledby="proposal-to-me-experience-tab">
+                                <div id="proposalToMeExperienceList" class="row">
+                                    <!-- 나에게 제안 온 체험 리스트가 렌더링 -->
+                                </div>
+                                <!-- 페이지네이션 버튼 -->
+                                <div class="pagination-container"
+                                     id="proposal-to-me-experience-pagination"></div>
+                            </div>
+
+                            <!-- 내가 수락한 체험 리스트 -->
+                            <div class="tab-pane fade" id="my-accepted-experience" role="tabpanel"
+                                 aria-labelledby="my-accepted-experience-tab">
+                                <div>
+                                    <div class="pb-4">
+                                        <input type="radio" id="is-experience-"
+                                               name="isExperienceByApplies" value="true" checked/>
+                                        지원
+                                        <input type="radio" id="zzimed-me-customers-noti-not-read"
+                                               name="isExperienceByApplies" value="false"/> 제안
+                                    </div>
+                                </div>
+                                <div id="myAcceptedExperienceList" class="row"></div>
+                                <!-- 내가 수락한 체험 리스트가 렌더링 -->
+
+                                <!-- 페이지네이션 버튼 -->
+                                <div class="pagination-container"
+                                     id="my-accepted-experience-pagination"></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+</main>
+
+<!-- ======= Footer ======= -->
+<footer id="footer" class="footer">
+    <div class="copyright">
+        &copy; Copyright <strong><span>nugunaTeam</span></strong>. All Rights Reserved
+    </div>
+    <div class="credits">
+        Designed by <a href="https://bootstrapmade.com/">BootstrapMade</a>
+    </div>
+</footer><!-- End Footer -->
+
+<a href="#" class="back-to-top d-flex align-items-center justify-content-center"><i
+        class="bi bi-arrow-up-short"></i></a>
+
+<!-- Vendor JS Files -->
+<script src="/assets/vendor/apexcharts/apexcharts.min.js"></script>
+<script src="/assets/vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
+<script src="/assets/vendor/chart.js/chart.umd.js"></script>
+<script src="/assets/vendor/echarts/echarts.min.js"></script>
+<script src="/assets/vendor/quill/quill.js"></script>
+<script src="/assets/vendor/simple-datatables/simple-datatables.js"></script>
+<script src="/assets/vendor/tinymce/tinymce.min.js"></script>
+<script src="/assets/vendor/php-email-form/validate.js"></script>
+<!-- Template Main JS File -->
+<script src="/assets/js/main.js"></script>
+
+<script>
+  $(document).ready(function () {
+    let userSeq = '${userSeq}';
+    let currentPage = 1;
+
+    sendMyAppliedExperienceList(1);
+
+    // 지원 리스트 탭 클릭 시 데이터 요청
+    $("#my-applied-experience-tab").on('click', function () {
+      sendMyAppliedExperienceList(1);
+    });
+
+    // 지원 리스트 전송 함수
+    function sendMyAppliedExperienceList(page) {
+      let sendData = {
+        'userSeq': userSeq,
+        'targetPage': page
+      };
+      $.ajax({
+        type: "GET",
+        url: "/api/customer/my/experience/apply-list",
+        data: $.param(sendData),
+        contentType: "application/x-www-form-urlencoded",
+        dataType: "json",
+        error: function (response) {
+          console.error("[ERROR] 지원 리스트 불러오기 실패하였습니다. 다시 시도해주세요.");
+        },
+        success: function (response) {
+          let {paginationInfo, applyInfos} = response;
+          renderMyAppliedExperienceList(applyInfos);
+          initializePagination(paginationInfo, 'my-applied-experience');
+        }
+      });
+    }
+
+    // 지원 리스트 렌더링 함수
+    function renderMyAppliedExperienceList(applyInfos) {
+      let htmlStr = "";
+      $.map(applyInfos, function (item) {
+        htmlStr += "<div class='card'>";
+        htmlStr += "<div class='card-body-y mt-2'>";
+        htmlStr += "<p><a href='/brand/" + item.storeSeq + "'>" + item.storeName
+            + "</a>님의 <a href='/mojip/" + item.postSeq + "'>모집글</a>에 지원했습니다.</p>";
+        htmlStr += "<p>진행 현황: ";
+        if (item.status === 'SENT') {
+          htmlStr += "<span style='color:green'>요청 진행중</span>";
+        } else if (item.status === 'REJECTED') {
+          htmlStr += "<span style='color:grey'>거절됨</span>";
+        }
+        htmlStr += "</p>";
+        htmlStr += "<p>날짜: " + item.applyDate.year + "년 " + item.applyDate.monthValue + "월 "
+            + item.applyDate.dayOfMonth + "일</p>";
+        htmlStr += "</div>";
+        htmlStr += "</div>";
+      });
+      $("#myAppliedExperienceList").html(htmlStr);
+    }
+
+    // 페이지 네이션 처리
+    function initializePagination(paginationInfo, page) {
+      let currentPage = paginationInfo.currentPage;
+      let startPage = paginationInfo.startPage;
+      let endPage = paginationInfo.endPage;
+      let hasNext = paginationInfo.hasNext;
+      let hasPrevious = paginationInfo.hasPrevious;
+
+      let paginationContainer = $("#" + page + "-pagination");
+
+      let paginationHTML = '';
+      if (hasPrevious) {
+        paginationHTML += '<button id="prev-block-button" class="btn btn-primary edit-btn" data-page="'
+            + (parseInt(currentPage) - 1) + '">&lt;</button>';
+      }
+
+      for (let i = startPage; i <= endPage; i++) {
+        paginationHTML += '<button class="btn ' + (i === currentPage ? 'btn-secondary'
+            : 'btn-primary') + ' edit-btn" data-page="' + i + '">' + i + '</button>';
+      }
+
+      if (hasNext) {
+        paginationHTML += '<button id="next-block-button" class="btn btn-primary edit-btn" data-page="'
+            + (parseInt(currentPage) + 1) + '">&gt;</button>';
+      }
+
+      paginationContainer.html(paginationHTML);
+    }
+
+    // 페이지 버튼 클릭 이벤트
+    $(document).on("click", ".btn.edit-btn", function (e) {
+      let pageNumber = parseInt($(this).data("page"));
+      if (pageNumber > 0) {
+        handlePageChange(
+            $(this).closest(".pagination-container").attr("id").replace("-pagination", ""),
+            pageNumber);
+      }
+    });
+
+    // 페이지 변경 핸들러
+    function handlePageChange(tab, page) {
+      currentPage = page;
+      if (tab === 'my-applied-experience') {
+        sendMyAppliedExperienceList(page);
+      }
+    }
+  });
+</script>
+
+
 </body>
+
 </html>


### PR DESCRIPTION
## [ 체험단 > MY > 체험 페이지 ]
<br>

### 1. 지원 리스트 보기

<img width="726" alt="스크린샷 2024-08-07 오후 5 28 38" src="https://github.com/user-attachments/assets/32311a44-7c0d-416d-bdd8-b5945de71c8d">

- 스토어명 클릭 시 스토어 브랜딩 페이지 이동 가능
- 모집글 클릭 시 해당 모집글로 이동 가능
- 페이지네이션 또한 가능

### 2. 제안 리스트 보기 + 수락 / 거절 기능

<img width="728" alt="스크린샷 2024-08-07 오후 5 40 48" src="https://github.com/user-attachments/assets/43087531-818e-40c0-ad1d-5e08380a3207">

<img width="735" alt="스크린샷 2024-08-07 오후 5 41 01" src="https://github.com/user-attachments/assets/9b6fcb6c-ddaa-4da3-833c-34ca3abb7cd2">

- 진행 혹은 거절된 제안 리스트 확인 가능
- 스토어명 클릭 시 스토어 브랜딩 페이지 이동 가능

#### 제안 리스트 보기 - 수락, 거절 버튼 누르면 수락/거절 처리 가능

<img width="723" alt="스크린샷 2024-08-07 오후 5 41 31" src="https://github.com/user-attachments/assets/2679c78a-73e5-4a33-9193-41db7e589711">


<img width="734" alt="스크린샷 2024-08-07 오후 5 41 41" src="https://github.com/user-attachments/assets/0d548b7d-aacc-459c-b48b-7872694fe79b">

- 제안에 대한 처리 이후 (수락, 거절) => 원래 페이지 ( 예시에서는 2페이지 )로 렌더링됨

<img width="721" alt="스크린샷 2024-08-07 오후 5 42 26" src="https://github.com/user-attachments/assets/8ac7b9c6-2d01-4308-a2d0-aa0dacf9af9e">

- 거절 이후
<img width="731" alt="스크린샷 2024-08-07 오후 5 42 42" src="https://github.com/user-attachments/assets/ea4cb30e-7cb3-43b7-abe7-005170c823f4">

### 3-1. 수락 리스트 (지원)

<img width="734" alt="스크린샷 2024-08-07 오후 5 49 43" src="https://github.com/user-attachments/assets/2799e493-e346-4dc8-be2c-35aa5fe47174">

- 스토어명 클릭 시 스토어 브랜딩 페이지로 이동
- 수락됨 / 노쇼 / 완료됨 표시
- 페이지네이션 가능

### 3-2. 수락 리스트 (제안)

<img width="727" alt="스크린샷 2024-08-07 오후 5 52 38" src="https://github.com/user-attachments/assets/312ad23f-a2a4-461d-b5cd-4fe0e3fec834">

- 스토어명 클릭 시 스토어 브랜딩 페이지로 이동
- 수락됨 / 노쇼 / 완료됨 표시
- 제안 내용 표시
- 페이지네이션 가능
